### PR TITLE
Fix detached SavedChat session bug and add mutual save-request approval flow

### DIFF
--- a/database.py
+++ b/database.py
@@ -25,7 +25,7 @@ if 'channel_binding=' in DATABASE_URL:
     DATABASE_URL = re.sub(r'[&?]channel_binding=[^&]*', '', DATABASE_URL)
 
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, pool_recycle=300)
-SessionLocal = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
+SessionLocal = scoped_session(sessionmaker(autocommit=False, autoflush=False, expire_on_commit=False, bind=engine))
 Base = declarative_base()
 
 # Many-to-many relationship table for user interests


### PR DESCRIPTION
### Motivation
- Prevent runtime SQLAlchemy error `Instance <SavedChat ...> is not bound to a Session` that occurred when ORM `SavedChat` objects were used after the DB session closed.
- Replace the immediate-save behavior with a mutual approval flow so both users are only saved after explicit acceptance.

### Description
- Added `get_saved_chat_entries(db, user_id)` to transform `SavedChat` ORM rows into plain detached entries (`partner_id`, `nickname`, `saved_on`) while the DB session is open. 
- Refactored saved-list rendering into `build_saved_chats_text(saved_entries)` and `build_saved_chats_keyboard(saved_entries)` and updated all saved-list entry points (`/saved` command, `view_saved_chats` callback, and remove flow) to use detached entries. 
- Introduced `SaveRequest` model and DB helpers `create_save_request`, `get_save_request`, and `resolve_save_request` in `database.py`, and replaced immediate `save_chat_partner` calls with a request/approval flow. 
- Added callback handlers `handle_accept_save_callback` and `handle_decline_save_callback` and wired `accept_save_*`/`decline_save_*` callbacks so partners receive an inline Accept/Decline prompt and accepted saves persist both directions. 
- Fixed related messaging and keyboard entries to use the detached data model and avoid touching session-bound ORM objects outside `with database.get_db()` contexts.

### Testing
- Ran `python -m py_compile anonymous_chat_bot.py database.py api/index.py api/webhook.py set_webhook.py` and compilation completed successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699169e87f8c8322947ed0f2092c5207)