### PR TITLE
Collapse request markups to one-liners and add saved/reconnect chat flow

### DIFF
--- a/anonymous_chat_bot.py
+++ b/anonymous_chat_bot.py
@@ -238,6 +238,7 @@ Your profile is ready! Use the menu below to start chatting or customize your pr
 
 👤 **Profile:**
 • `/profile` - View/edit your profile
+• `/saved` - View your mutually saved chats
 • `/interests` - Set your interests
 • 😊 Set Mood - Show your current vibe
 
@@ -448,6 +449,7 @@ class Keyboards:
             [InlineKeyboardButton("🎁 Send Gift", callback_data='send_gift'),
              InlineKeyboardButton("💬 Compliment", callback_data='send_compliment')],
             [InlineKeyboardButton("👤 View Profile", callback_data='view_partner_profile')],
+            [InlineKeyboardButton("💾 Save Chat", callback_data='save_chat')],
             [InlineKeyboardButton("⏭️ Skip", callback_data='skip_chat'),
              InlineKeyboardButton("🛑 End", callback_data='end_chat')],
             [InlineKeyboardButton("🚨 Report", callback_data='report_user')]
@@ -674,6 +676,59 @@ class MatchmakingService:
 
 # Global service instance
 matchmaking = MatchmakingService()
+save_requests: Dict[int, int] = {}
+reconnect_requests: Dict[int, int] = {}
+
+
+def cleanup_save_requests(user_id: int, partner_id: Optional[int] = None) -> None:
+    """Clear pending save requests for ended chats"""
+    save_requests.pop(user_id, None)
+    if partner_id is not None:
+        save_requests.pop(partner_id, None)
+
+    stale_keys = [
+        key for key, requester_id in save_requests.items()
+        if requester_id == user_id or (partner_id is not None and requester_id == partner_id)
+    ]
+    for key in stale_keys:
+        save_requests.pop(key, None)
+
+
+def cleanup_reconnect_requests(user_id: int, partner_id: Optional[int] = None) -> None:
+    """Clear pending reconnect requests for ended chats"""
+    reconnect_requests.pop(user_id, None)
+    if partner_id is not None:
+        reconnect_requests.pop(partner_id, None)
+
+    stale_keys = [
+        key for key, requester_id in reconnect_requests.items()
+        if requester_id == user_id or (partner_id is not None and requester_id == partner_id)
+    ]
+    for key in stale_keys:
+        reconnect_requests.pop(key, None)
+
+def build_save_request_markup() -> InlineKeyboardMarkup:
+    """Build partner-facing save request action panel"""
+    return InlineKeyboardMarkup([[InlineKeyboardButton("✅ Accept", callback_data='accept_save')], [InlineKeyboardButton("❌ Decline", callback_data='decline_save')]])
+
+
+def build_reconnect_request_markup() -> InlineKeyboardMarkup:
+    """Build partner-facing reconnect request action panel"""
+    return InlineKeyboardMarkup([[InlineKeyboardButton("✅ Accept Reconnect", callback_data='accept_reconnect')], [InlineKeyboardButton("❌ Decline", callback_data='decline_reconnect')]])
+
+
+def build_requester_cancel_save_markup() -> InlineKeyboardMarkup:
+    """Build requester panel for canceling pending save request"""
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton("🗑 Delete My Save Request", callback_data='cancel_save_request')]
+    ])
+
+
+def build_requester_cancel_reconnect_markup() -> InlineKeyboardMarkup:
+    """Build requester panel for canceling pending reconnect request"""
+    return InlineKeyboardMarkup([
+        [InlineKeyboardButton("🗑 Delete My Reconnect Request", callback_data='cancel_reconnect_request')]
+    ])
 
 # Nicknames for users
 NICKNAMES = [
@@ -817,6 +872,8 @@ async def handle_skip_chat(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     """Handle skipping current chat"""
     user_id = update.effective_user.id
     partner_id = await matchmaking.end_chat(user_id)
+    cleanup_save_requests(user_id, partner_id)
+    cleanup_reconnect_requests(user_id, partner_id)
     
     if partner_id:
         await update.message.reply_text(Messages.SKIPPED_CHAT)
@@ -835,6 +892,8 @@ async def handle_end_chat(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     """Handle ending chat"""
     user_id = update.effective_user.id
     partner_id = await matchmaking.end_chat(user_id)
+    cleanup_save_requests(user_id, partner_id)
+    cleanup_reconnect_requests(user_id, partner_id)
     await matchmaking.remove_from_queue(user_id)
     
     if partner_id:
@@ -866,6 +925,8 @@ async def handle_report_user(update: Update, context: ContextTypes.DEFAULT_TYPE)
     
     # End the chat
     await matchmaking.end_chat(user_id)
+    cleanup_save_requests(user_id, partner_id)
+    cleanup_reconnect_requests(user_id, partner_id)
     await update.message.reply_text(Messages.REPORT_SENT, reply_markup=Keyboards.main_menu())
     
     if partner_id:
@@ -874,6 +935,62 @@ async def handle_report_user(update: Update, context: ContextTypes.DEFAULT_TYPE)
 async def profile_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle /profile command"""
     await show_profile(update, context)
+
+
+async def build_saved_panel(user_id: int) -> tuple:
+    """Build saved list text and keyboard panel"""
+    saved_rows = []
+
+    with database.get_db() as db:
+        saved_chats = database.list_saved_chats(db, user_id)
+        for saved_chat in saved_chats:
+            partner = database.get_user(db, saved_chat.partner_id)
+            nickname = partner.nickname if partner else f"User {saved_chat.partner_id}"
+            saved_time = saved_chat.created_at.strftime("%Y-%m-%d %H:%M UTC")
+            saved_rows.append({
+                'partner_id': saved_chat.partner_id,
+                'nickname': nickname,
+                'saved_time': saved_time
+            })
+
+    if not saved_rows:
+        text = "💾 Your saved chat list is empty."
+        keyboard = InlineKeyboardMarkup([
+            [InlineKeyboardButton("🔄 Refresh", callback_data='refresh_saved_list')]
+        ])
+        return text, keyboard
+
+    lines = ["💾 Saved Chat Panel"]
+    keyboard_rows = []
+    for index, row in enumerate(saved_rows, start=1):
+        lines.append(f"{index}. {row['nickname']} — {row['saved_time']}")
+        keyboard_rows.append([
+            InlineKeyboardButton(
+                f"🔄 Reconnect #{index}",
+                callback_data=f"reconnect_saved_{row['partner_id']}"
+            ),
+            InlineKeyboardButton(
+                f"🗑 Remove #{index}",
+                callback_data=f"delete_saved_{row['partner_id']}"
+            )
+        ])
+
+    keyboard_rows.append([InlineKeyboardButton("🔄 Refresh", callback_data='refresh_saved_list')])
+    return "\n".join(lines), InlineKeyboardMarkup(keyboard_rows)
+
+
+async def saved_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /saved command"""
+    user_id = update.effective_user.id
+
+    try:
+        text, keyboard = await build_saved_panel(user_id)
+    except Exception as e:
+        logger.error(f"Failed to load saved chats for {user_id}: {e}")
+        await update.message.reply_text("❌ Could not load saved chats right now. Please try again.")
+        return
+
+    await update.message.reply_text(text, reply_markup=keyboard)
 
 async def show_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Show user profile"""
@@ -931,8 +1048,7 @@ async def privacy_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle all button callbacks"""
     query = update.callback_query
-    await query.answer()
-    
+
     user_id = query.from_user.id
     data = query.data
     
@@ -980,6 +1096,36 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     
     elif data == 'report_user':
         await handle_report_user_callback(query, context)
+
+    elif data == 'save_chat':
+        await handle_save_chat_callback(query, context)
+
+    elif data == 'accept_save':
+        await handle_accept_save_callback(query, context)
+
+    elif data == 'decline_save':
+        await handle_decline_save_callback(query, context)
+
+    elif data == 'cancel_save_request':
+        await handle_cancel_save_request_callback(query, context)
+
+    elif data.startswith('reconnect_saved_'):
+        await handle_saved_reconnect_request_callback(query, context)
+
+    elif data.startswith('delete_saved_'):
+        await handle_delete_saved_chat_callback(query, context)
+
+    elif data == 'refresh_saved_list':
+        await handle_refresh_saved_list_callback(query, context)
+
+    elif data == 'accept_reconnect':
+        await handle_accept_reconnect_callback(query, context)
+
+    elif data == 'decline_reconnect':
+        await handle_decline_reconnect_callback(query, context)
+
+    elif data == 'cancel_reconnect_request':
+        await handle_cancel_reconnect_request_callback(query, context)
     
     elif data == 'back_to_chat':
         await query.edit_message_text(
@@ -1455,6 +1601,8 @@ async def handle_skip_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) -
     """Handle skip chat button callback"""
     user_id = query.from_user.id
     partner_id = await matchmaking.end_chat(user_id)
+    cleanup_save_requests(user_id, partner_id)
+    cleanup_reconnect_requests(user_id, partner_id)
     
     if partner_id:
         await query.edit_message_text(Messages.SKIPPED_CHAT)
@@ -1472,6 +1620,8 @@ async def handle_end_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) ->
     """Handle end chat button callback"""
     user_id = query.from_user.id
     partner_id = await matchmaking.end_chat(user_id)
+    cleanup_save_requests(user_id, partner_id)
+    cleanup_reconnect_requests(user_id, partner_id)
     await matchmaking.remove_from_queue(user_id)
     
     if partner_id:
@@ -1499,10 +1649,342 @@ async def handle_report_user_callback(query, context: ContextTypes.DEFAULT_TYPE)
     
     # End the chat
     await matchmaking.end_chat(user_id)
+    cleanup_save_requests(user_id, partner_id)
+    cleanup_reconnect_requests(user_id, partner_id)
     await query.edit_message_text(Messages.REPORT_SENT, reply_markup=Keyboards.main_menu())
     
     if partner_id:
         await context.bot.send_message(partner_id, Messages.CHAT_ENDED_BY_PARTNER, reply_markup=Keyboards.main_menu())
+
+
+async def handle_save_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle save chat request"""
+    user_id = query.from_user.id
+    partner_id = matchmaking.get_partner(user_id)
+
+    if not partner_id:
+        await query.answer("❌ Not in chat", show_alert=True)
+        return
+
+    try:
+        with database.get_db() as db:
+            requester_count = database.count_saved_chats(db, user_id)
+            partner_count = database.count_saved_chats(db, partner_id)
+            already_saved = database.has_saved_chat(db, user_id, partner_id)
+    except Exception as e:
+        logger.error(f"Save chat precheck failed for {user_id}: {e}")
+        await query.answer("❌ Save system is temporarily unavailable.", show_alert=True)
+        return
+
+    if already_saved:
+        await query.answer("💾 This chat is already saved.", show_alert=True)
+        await context.bot.send_message(user_id, "💾 Already saved. This chat is already in your saved list.")
+        return
+
+    if requester_count >= 3:
+        await query.answer("⚠️ You already reached the max limit of 3 saved chats.", show_alert=True)
+        return
+
+    if partner_count >= 3:
+        await query.answer("⚠️ Your partner already reached the max limit of 3 saved chats.", show_alert=True)
+        return
+
+    if partner_id in save_requests and save_requests[partner_id] != user_id:
+        await query.answer("⚠️ Partner already has a pending save request.", show_alert=True)
+        return
+
+    save_requests[partner_id] = user_id
+    request_buttons = build_save_request_markup()
+
+    try:
+        await context.bot.send_message(
+            partner_id,
+            "💾 Your partner wants to save this chat. Accept?",
+            reply_markup=request_buttons
+        )
+    except Exception as e:
+        save_requests.pop(partner_id, None)
+        logger.error(f"Failed to send save request panel from {user_id} to {partner_id}: {e}")
+        await query.answer("❌ Could not send save request to partner.", show_alert=True)
+        return
+
+    await query.answer("💾 Save request sent", show_alert=False)
+    requester_panel = build_requester_cancel_save_markup()
+    await context.bot.send_message(
+        user_id,
+        "⏳ Save request sent. Partner received Accept/Delete panel.",
+        reply_markup=requester_panel
+    )
+
+
+async def handle_accept_save_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle accepting a save chat request"""
+    user_id = query.from_user.id
+    requester_id = save_requests.pop(user_id, None)
+
+    if not requester_id:
+        await query.answer("❌ No pending save request.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(user_id) != requester_id:
+        await query.edit_message_text("❌ Save request expired.")
+        await context.bot.send_message(requester_id, "❌ Your save request expired.")
+        return
+
+    try:
+        with database.get_db() as db:
+            requester_count = database.count_saved_chats(db, requester_id)
+            accepter_count = database.count_saved_chats(db, user_id)
+            if requester_count >= 3 or accepter_count >= 3:
+                await query.edit_message_text("⚠️ Save failed: one user reached the 3-chat limit.")
+                await context.bot.send_message(requester_id, "⚠️ Save failed because one user reached the 3-chat limit.")
+                return
+
+            saved = database.save_chat_mutual(db, requester_id, user_id)
+    except Exception as e:
+        logger.error(f"Save accept failed for requester {requester_id} and accepter {user_id}: {e}")
+        await query.edit_message_text("❌ Failed to save chat. Please try again later.")
+        await context.bot.send_message(requester_id, "❌ Your save request failed due to a temporary issue.")
+        return
+
+    if not saved:
+        await query.edit_message_text("💾 This chat was already saved.")
+        await context.bot.send_message(requester_id, "💾 Your chat was already saved earlier.")
+        return
+
+    await query.edit_message_text("✅ Save accepted. Chat saved for both users.")
+    await context.bot.send_message(user_id, "✅ Save done. Chat saved for both users.")
+    await context.bot.send_message(requester_id, "✅ Save done. Partner accepted and chat saved for both users.")
+
+
+async def handle_decline_save_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle declining a save chat request"""
+    user_id = query.from_user.id
+    requester_id = save_requests.pop(user_id, None)
+
+    await query.edit_message_text("❌ Save request declined.")
+    if requester_id:
+        await context.bot.send_message(requester_id, "❌ Your save request was declined.")
+
+
+async def handle_cancel_save_request_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Requester cancels their own pending save request"""
+    user_id = query.from_user.id
+    cancelled_partner = None
+
+    for partner_id, requester_id in list(save_requests.items()):
+        if requester_id == user_id:
+            cancelled_partner = partner_id
+            save_requests.pop(partner_id, None)
+            break
+
+    if not cancelled_partner:
+        await query.answer("❌ No pending save request to delete.", show_alert=True)
+        return
+
+    await query.answer("🗑 Save request deleted.", show_alert=False)
+    await query.edit_message_text("✅ Your save request was deleted.")
+    try:
+        await context.bot.send_message(cancelled_partner, "⚠️ Save request was deleted by requester.")
+    except Exception:
+        pass
+
+
+async def handle_cancel_reconnect_request_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Requester cancels their own pending reconnect request"""
+    user_id = query.from_user.id
+    cancelled_partner = None
+
+    for partner_id, requester_id in list(reconnect_requests.items()):
+        if requester_id == user_id:
+            cancelled_partner = partner_id
+            reconnect_requests.pop(partner_id, None)
+            break
+
+    if not cancelled_partner:
+        await query.answer("❌ No pending reconnect request to delete.", show_alert=True)
+        return
+
+    await query.answer("🗑 Reconnect request deleted.", show_alert=False)
+    await query.edit_message_text("✅ Your reconnect request was deleted.")
+    try:
+        await context.bot.send_message(cancelled_partner, "⚠️ Reconnect request was deleted by requester.")
+    except Exception:
+        pass
+
+
+async def handle_saved_reconnect_request_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle reconnect request from /saved list"""
+    user_id = query.from_user.id
+    callback_data = query.data
+
+    if matchmaking.get_partner(user_id):
+        await query.answer("❌ End current chat before reconnecting.", show_alert=True)
+        return
+
+    if user_id in matchmaking.waiting_users:
+        await query.answer("❌ Stop search before reconnecting.", show_alert=True)
+        return
+
+    if not callback_data.startswith('reconnect_saved_'):
+        await query.answer("❌ Invalid reconnect request.", show_alert=True)
+        return
+
+    try:
+        partner_id = int(callback_data.split('reconnect_saved_')[1])
+    except ValueError:
+        await query.answer("❌ Invalid reconnect request.", show_alert=True)
+        return
+
+    try:
+        with database.get_db() as db:
+            is_mutual_saved = database.has_saved_chat(db, user_id, partner_id) and database.has_saved_chat(db, partner_id, user_id)
+            partner = database.get_user(db, partner_id)
+            requester = database.get_user(db, user_id)
+    except Exception as e:
+        logger.error(f"Reconnect precheck failed for {user_id}: {e}")
+        await query.answer("❌ Reconnect is temporarily unavailable.", show_alert=True)
+        return
+
+    if not is_mutual_saved:
+        await query.answer("❌ This saved chat is no longer available.", show_alert=True)
+        return
+
+    if not partner:
+        await query.answer("❌ Partner not available.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(partner_id):
+        await query.answer("❌ Partner is in another chat right now.", show_alert=True)
+        return
+
+    if partner_id in matchmaking.waiting_users:
+        await query.answer("❌ Partner is currently searching. Try again shortly.", show_alert=True)
+        return
+
+    reconnect_requests[partner_id] = user_id
+    requester_name = requester.nickname if requester else "Your saved partner"
+    reconnect_buttons = build_reconnect_request_markup()
+
+    try:
+        await context.bot.send_message(
+            partner_id,
+            f"🔄 {requester_name} wants to reconnect from saved chats. Accept?",
+            reply_markup=reconnect_buttons
+        )
+    except Exception as e:
+        reconnect_requests.pop(partner_id, None)
+        logger.error(f"Failed to send reconnect request panel from {user_id} to {partner_id}: {e}")
+        await query.answer("❌ Could not send reconnect request to partner.", show_alert=True)
+        return
+
+    await query.answer("🔄 Reconnect request sent", show_alert=False)
+    requester_panel = build_requester_cancel_reconnect_markup()
+    await context.bot.send_message(
+        user_id,
+        "⏳ Reconnect request sent. Partner received Accept/Delete panel.",
+        reply_markup=requester_panel
+    )
+    await context.bot.send_message(user_id, "⏳ Waiting for partner acceptance...")
+
+
+async def handle_accept_reconnect_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle reconnect acceptance"""
+    user_id = query.from_user.id
+    requester_id = reconnect_requests.pop(user_id, None)
+
+    if not requester_id:
+        await query.answer("❌ No pending reconnect request.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(user_id) or matchmaking.get_partner(requester_id):
+        await query.edit_message_text("❌ Reconnect failed: one user is already in chat.")
+        await context.bot.send_message(requester_id, "❌ Reconnect failed because one user is already in another chat.")
+        return
+
+    if user_id in matchmaking.waiting_users or requester_id in matchmaking.waiting_users:
+        await query.edit_message_text("❌ Reconnect failed: one user is currently searching.")
+        await context.bot.send_message(requester_id, "❌ Reconnect failed because one user is currently searching.")
+        return
+
+    try:
+        async with matchmaking.lock:
+            matchmaking.active_sessions[requester_id] = user_id
+            matchmaking.active_sessions[user_id] = requester_id
+
+            with database.get_db() as db:
+                database.create_chat_session(db, requester_id, user_id)
+    except Exception as e:
+        matchmaking.active_sessions.pop(requester_id, None)
+        matchmaking.active_sessions.pop(user_id, None)
+        logger.error(f"Reconnect accept failed for requester {requester_id} and accepter {user_id}: {e}")
+        await query.edit_message_text("❌ Reconnect failed. Please try again later.")
+        await context.bot.send_message(requester_id, "❌ Reconnect failed due to a temporary issue.")
+        return
+
+    await query.edit_message_text("✅ Reconnected! You can chat now.")
+    await context.bot.send_message(user_id, "✅ Reconnect done. You are now connected.", reply_markup=Keyboards.chat_controls())
+    await context.bot.send_message(requester_id, "✅ Reconnect done! Your partner accepted.", reply_markup=Keyboards.chat_controls())
+
+
+async def handle_decline_reconnect_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle reconnect decline"""
+    user_id = query.from_user.id
+    requester_id = reconnect_requests.pop(user_id, None)
+
+    await query.edit_message_text("❌ Reconnect request declined.")
+    if requester_id:
+        await context.bot.send_message(requester_id, "❌ Reconnect request declined by your saved partner.")
+
+
+async def handle_delete_saved_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Delete a saved chat from /saved list"""
+    user_id = query.from_user.id
+    callback_data = query.data
+
+    if not callback_data.startswith('delete_saved_'):
+        await query.answer("❌ Invalid delete request.", show_alert=True)
+        return
+
+    try:
+        partner_id = int(callback_data.split('delete_saved_')[1])
+    except ValueError:
+        await query.answer("❌ Invalid delete request.", show_alert=True)
+        return
+
+    try:
+        with database.get_db() as db:
+            deleted = database.delete_saved_chat(db, user_id, partner_id, delete_mutual=False)
+    except Exception as e:
+        logger.error(f"Delete saved chat failed for {user_id}: {e}")
+        await query.answer("❌ Could not delete saved chat right now.", show_alert=True)
+        return
+
+    if deleted <= 0:
+        await query.answer("⚠️ Saved chat was not found.", show_alert=True)
+        return
+
+    await query.answer("🗑 Saved chat removed.", show_alert=False)
+    try:
+        text, keyboard = await build_saved_panel(user_id)
+        await query.edit_message_text(text, reply_markup=keyboard)
+    except Exception as e:
+        logger.error(f"Failed to refresh saved panel after delete for {user_id}: {e}")
+        await query.edit_message_text("✅ Saved chat removed. Use /saved to open panel again.")
+
+
+async def handle_refresh_saved_list_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Refresh saved list panel"""
+    user_id = query.from_user.id
+    try:
+        text, keyboard = await build_saved_panel(user_id)
+    except Exception as e:
+        logger.error(f"Failed to refresh saved list for {user_id}: {e}")
+        await query.answer("❌ Could not refresh saved list.", show_alert=True)
+        return
+
+    await query.answer("🔄 Saved list refreshed", show_alert=False)
+    await query.edit_message_text(text, reply_markup=keyboard)
 
 # Admin Functions
 async def admin_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -2111,6 +2593,7 @@ def main() -> None:
     application.add_handler(CommandHandler("stop", stop_command))
     application.add_handler(CommandHandler("report", report_command))
     application.add_handler(CommandHandler("profile", profile_command))
+    application.add_handler(CommandHandler("saved", saved_command))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("privacy", privacy_command))
     application.add_handler(CommandHandler("viewonce", viewonce_command))
@@ -2130,6 +2613,7 @@ def main() -> None:
             BotCommand("skip", "Skip current chat partner"),
             BotCommand("stop", "End current chat"),
             BotCommand("profile", "View/edit your profile"),
+            BotCommand("saved", "View your saved chats"),
             BotCommand("viewonce", "Send a view-once disappearing photo"),
             BotCommand("help", "Show help menu"),
             BotCommand("privacy", "Privacy information"),

--- a/database.py
+++ b/database.py
@@ -25,7 +25,7 @@ if 'channel_binding=' in DATABASE_URL:
     DATABASE_URL = re.sub(r'[&?]channel_binding=[^&]*', '', DATABASE_URL)
 
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, pool_recycle=300)
-SessionLocal = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
+SessionLocal = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine, expire_on_commit=False))
 Base = declarative_base()
 
 # Many-to-many relationship table for user interests
@@ -121,6 +121,17 @@ class BroadcastMessage(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     completed_at = Column(DateTime, nullable=True)
 
+class SavedChat(Base):
+    __tablename__ = 'saved_chats'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(BigInteger, ForeignKey('users.user_id'), nullable=False)
+    partner_id = Column(BigInteger, ForeignKey('users.user_id'), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", foreign_keys=[user_id])
+    partner = relationship("User", foreign_keys=[partner_id])
+
 @contextmanager
 def get_db():
     """Database session context manager"""
@@ -165,6 +176,48 @@ def init_database():
                     conn.commit()
                 except Exception:
                     pass  # Column might already exist or other issue
+
+            # Ensure saved chats table exists for mutual save feature
+            try:
+                conn.execute(text("""
+                    CREATE TABLE IF NOT EXISTS saved_chats (
+                        id SERIAL PRIMARY KEY,
+                        user_id BIGINT,
+                        partner_id BIGINT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )
+                """))
+
+                # Compatibility migrations for older schemas
+                conn.execute(text("ALTER TABLE saved_chats ADD COLUMN IF NOT EXISTS user_id BIGINT"))
+                conn.execute(text("ALTER TABLE saved_chats ADD COLUMN IF NOT EXISTS partner_id BIGINT"))
+                conn.execute(text("ALTER TABLE saved_chats ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"))
+
+                # Backfill from legacy column names if present
+                try:
+                    conn.execute(text("UPDATE saved_chats SET user_id = owner_id WHERE user_id IS NULL"))
+                except Exception:
+                    pass
+                try:
+                    conn.execute(text("UPDATE saved_chats SET partner_id = partner_user_id WHERE partner_id IS NULL"))
+                except Exception:
+                    pass
+
+                # Add FK constraints if missing (safe no-op on error)
+                try:
+                    conn.execute(text("ALTER TABLE saved_chats ADD CONSTRAINT fk_saved_chats_user_id FOREIGN KEY (user_id) REFERENCES users(user_id)"))
+                except Exception:
+                    pass
+                try:
+                    conn.execute(text("ALTER TABLE saved_chats ADD CONSTRAINT fk_saved_chats_partner_id FOREIGN KEY (partner_id) REFERENCES users(user_id)"))
+                except Exception:
+                    pass
+
+                conn.execute(text("CREATE INDEX IF NOT EXISTS idx_saved_chats_user_id ON saved_chats(user_id)"))
+                conn.execute(text("CREATE INDEX IF NOT EXISTS idx_saved_chats_partner_id ON saved_chats(partner_id)"))
+                conn.commit()
+            except Exception:
+                pass
             
             logger.info("Database migration completed successfully")
     except Exception as e:
@@ -408,3 +461,48 @@ def update_broadcast_stats(db, broadcast_id: int, sent_count: int, failed_count:
         broadcast.failed_count = failed_count
         broadcast.completed_at = datetime.utcnow()
         db.flush()
+
+def count_saved_chats(db, user_id: int) -> int:
+    """Get saved chat count for a user"""
+    return db.query(SavedChat).filter(SavedChat.user_id == user_id).count()
+
+def has_saved_chat(db, user_id: int, partner_id: int) -> bool:
+    """Check if a saved chat already exists between users for this direction"""
+    return db.query(SavedChat).filter(
+        SavedChat.user_id == user_id,
+        SavedChat.partner_id == partner_id
+    ).first() is not None
+
+def save_chat_mutual(db, user_a_id: int, user_b_id: int) -> bool:
+    """Save chat for both users if not already saved"""
+    if has_saved_chat(db, user_a_id, user_b_id) or has_saved_chat(db, user_b_id, user_a_id):
+        return False
+
+    db.add(SavedChat(user_id=user_a_id, partner_id=user_b_id))
+    db.add(SavedChat(user_id=user_b_id, partner_id=user_a_id))
+    db.flush()
+    return True
+
+def list_saved_chats(db, user_id: int) -> List[SavedChat]:
+    """Return all saved chats for a user"""
+    return db.query(SavedChat).filter(
+        SavedChat.user_id == user_id
+    ).order_by(SavedChat.created_at.desc()).all()
+
+def delete_saved_chat(db, user_id: int, partner_id: int, delete_mutual: bool = False) -> int:
+    """Delete saved chat for one side, or both sides if delete_mutual=True"""
+    query = db.query(SavedChat).filter(
+        SavedChat.user_id == user_id,
+        SavedChat.partner_id == partner_id
+    )
+    deleted = query.delete(synchronize_session=False)
+
+    if delete_mutual:
+        deleted += db.query(SavedChat).filter(
+            SavedChat.user_id == partner_id,
+            SavedChat.partner_id == user_id
+        ).delete(synchronize_session=False)
+
+    db.flush()
+    return deleted
+


### PR DESCRIPTION
### Motivation
- Address repeated `IndentationError` seen in deployment logs around the multiline InlineKeyboardButton lines by minimizing indentation-sensitive code in request markups. 
- Provide a mutually-saved-chat feature and a saved-chat reconnect flow so users can store and reconnect with partners, and ensure pending request state is cleaned up when chats end. 

### Description
- Replace multiline button list builders with single-line `build_save_request_markup()` and `build_reconnect_request_markup()` constructors to reduce parser-sensitive indentation. 
- Add in-memory request tracking (`save_requests`, `reconnect_requests`), cleanup helpers, UI builders, `/saved` command, `build_saved_panel()` and full callback handlers for save/reconnect/create/delete/refresh flows. 
- Extend the database with a `SavedChat` model, migration-safe DDL in `init_database()`, and DAO helpers: `count_saved_chats()`, `has_saved_chat()`, `save_chat_mutual()`, `list_saved_chats()`, and `delete_saved_chat()`. 
- Tweak session settings with `expire_on_commit=False` to avoid lazy-loading surprises and add cleanup calls in chat lifecycle handlers to prevent stale requests. 

### Testing
- Successfully ran `python -m py_compile anonymous_chat_bot.py database.py` with no compile errors. 
- Verified presence of the new single-line builders and handlers via `rg`/static checks and confirmed the repository changes were committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991ec8adaf08322a9f9725e974747dc)