### PR TITLE
Support legacy saved_chats schema and add saved-chat UI/flows

### DIFF
--- a/anonymous_chat_bot.py
+++ b/anonymous_chat_bot.py
@@ -218,6 +218,21 @@ Your profile is ready! Use the menu below to start chatting or customize your pr
 📅 **Member Since:** {}"""
     
     WARNING_MESSAGE = "⚠️ **Content Warning**\n\nYour message may contain inappropriate content. Please be respectful in your conversations."
+    SAVE_REQUEST_SENT = "💾 Save request sent to your partner. Waiting for response."
+    SAVE_REQUEST_RECEIVED = "💾 Your partner wants to save this chat. Accept?"
+    SAVE_ACCEPTED_SENDER = "✅ Your partner accepted. Chat saved successfully."
+    SAVE_ACCEPTED_PARTNER = "✅ You accepted. This chat has been saved."
+    SAVE_DECLINED_SENDER = "❌ Your partner declined the save request."
+    SAVE_DECLINED_PARTNER = "❌ You declined the save request."
+    SAVE_LIMIT_REACHED = "⚠️ You already have 3 saved chats. Delete one from /saved before saving a new chat."
+    SAVE_ALREADY_EXISTS = "ℹ️ This chat is already saved in your list."
+    SAVED_EMPTY = "📭 You do not have any saved chats yet."
+    SAVED_MENU_TITLE = "💾 **Your Saved Chats**\n\nMaximum saved chats: 3"
+    RECONNECT_REQUEST_SENT = "🔁 Reconnect request sent. Waiting for your saved partner response."
+    RECONNECT_REQUEST_RECEIVED = "🔁 Your saved chat partner wants to reconnect now. Accept?"
+    RECONNECT_ACCEPTED = "✅ Reconnected with your saved partner."
+    RECONNECT_DECLINED_SENDER = "❌ Your saved partner declined the reconnect request."
+    RECONNECT_DECLINED_PARTNER = "❌ You declined the reconnect request."
     
     HELP_MENU = """❓ **Help & Commands**
 
@@ -238,6 +253,7 @@ Your profile is ready! Use the menu below to start chatting or customize your pr
 
 👤 **Profile:**
 • `/profile` - View/edit your profile
+• `/saved` - View your saved chat list
 • `/interests` - Set your interests
 • 😊 Set Mood - Show your current vibe
 
@@ -437,6 +453,7 @@ class Keyboards:
     def main_menu():
         return InlineKeyboardMarkup([
             [InlineKeyboardButton("💬 Find Partner", callback_data='find_partner')],
+            [InlineKeyboardButton("💾 Saved Chats", callback_data='view_saved_chats')],
             [InlineKeyboardButton("👤 My Profile", callback_data='view_profile'), 
              InlineKeyboardButton("❓ Help", callback_data='help_menu')],
             [InlineKeyboardButton("🔒 Privacy", callback_data='privacy_info')]
@@ -447,11 +464,33 @@ class Keyboards:
         return InlineKeyboardMarkup([
             [InlineKeyboardButton("🎁 Send Gift", callback_data='send_gift'),
              InlineKeyboardButton("💬 Compliment", callback_data='send_compliment')],
+            [InlineKeyboardButton("💾 Save Chat", callback_data='save_chat')],
             [InlineKeyboardButton("👤 View Profile", callback_data='view_partner_profile')],
             [InlineKeyboardButton("⏭️ Skip", callback_data='skip_chat'),
              InlineKeyboardButton("🛑 End", callback_data='end_chat')],
             [InlineKeyboardButton("🚨 Report", callback_data='report_user')]
         ])
+
+    @staticmethod
+    def save_request_panel(requester_id: int):
+        return InlineKeyboardMarkup([
+            [InlineKeyboardButton("✅ Accept", callback_data=f'save_accept_{requester_id}'),
+             InlineKeyboardButton("❌ Decline", callback_data=f'save_decline_{requester_id}')]
+        ])
+
+    @staticmethod
+    def reconnect_request_panel(requester_id: int):
+        return InlineKeyboardMarkup([
+            [InlineKeyboardButton("✅ Accept", callback_data=f'reconnect_accept_{requester_id}'),
+             InlineKeyboardButton("❌ Decline", callback_data=f'reconnect_decline_{requester_id}')]
+        ])
+
+    @staticmethod
+    def saved_chat_row(partner_id: int):
+        return [
+            InlineKeyboardButton("🔁 Reconnect", callback_data=f'saved_reconnect_{partner_id}'),
+            InlineKeyboardButton("🗑️ Delete", callback_data=f'saved_delete_{partner_id}')
+        ]
     
     @staticmethod
     def games_menu():
@@ -498,6 +537,7 @@ class Keyboards:
             [InlineKeyboardButton("✏️ Edit Profile", callback_data='edit_profile')],
             [InlineKeyboardButton("💭 Set Interests", callback_data='set_interests')],
             [InlineKeyboardButton("😊 Set Mood", callback_data='set_mood')],
+            [InlineKeyboardButton("💾 Saved Chats", callback_data='view_saved_chats')],
             [InlineKeyboardButton("🌐 Language", callback_data='change_language')],
             [InlineKeyboardButton("🔙 Back to Menu", callback_data='main_menu')]
         ])
@@ -650,6 +690,26 @@ class MatchmakingService:
     def get_partner(self, user_id: int) -> Optional[int]:
         """Get current chat partner"""
         return self.active_sessions.get(user_id)
+
+    async def connect_saved_partners(self, user_a_id: int, user_b_id: int) -> bool:
+        """Create active session for saved partners safely"""
+        async with self.lock:
+            if user_a_id in self.active_sessions or user_b_id in self.active_sessions:
+                return False
+            if user_a_id in self.waiting_users or user_b_id in self.waiting_users:
+                return False
+
+            for uid in [user_a_id, user_b_id]:
+                if uid in self.retry_tasks:
+                    self.retry_tasks[uid].cancel()
+                    del self.retry_tasks[uid]
+
+            self.active_sessions[user_a_id] = user_b_id
+            self.active_sessions[user_b_id] = user_a_id
+
+            with database.get_db() as db:
+                database.create_chat_session(db, user_a_id, user_b_id)
+            return True
     
     async def start_matching_with_retry(self, user_id: int, context: ContextTypes.DEFAULT_TYPE):
         """Start matching process with retry logic"""
@@ -708,6 +768,32 @@ def contains_inappropriate_content(text: str) -> bool:
         if re.search(pattern, text.lower()):
             return True
     return False
+
+
+def build_saved_chat_menu(user_id: int):
+    """Build saved chat text and panel"""
+    with database.get_db() as db:
+        saved_chats = database.get_saved_chats_for_owner(db, user_id)
+
+        if not saved_chats:
+            return Messages.SAVED_EMPTY, Keyboards.main_menu()
+
+        lines = [Messages.SAVED_MENU_TITLE, ""]
+        buttons = []
+
+        for index, saved_chat in enumerate(saved_chats, start=1):
+            partner = database.get_user(db, saved_chat.partner_id)
+            partner_name = partner.nickname if partner else f"User {saved_chat.partner_id}"
+            saved_date = saved_chat.created_at.strftime('%Y-%m-%d %H:%M')
+            lines.append(f"{index}. **{partner_name}**")
+            lines.append(f"   🆔 `{saved_chat.partner_id}`")
+            lines.append(f"   📅 Saved at: {saved_date}")
+            lines.append("")
+            buttons.append(Keyboards.saved_chat_row(saved_chat.partner_id))
+
+        buttons.append([InlineKeyboardButton("🔄 Refresh", callback_data='saved_refresh')])
+        buttons.append([InlineKeyboardButton("🏠 Main Menu", callback_data='main_menu')])
+        return "\n".join(lines).strip(), InlineKeyboardMarkup(buttons)
     
 USERNAME_PATTERN = re.compile(r'@\w+')
 PHONE_PATTERN = re.compile(r'(\+?\d[\d\s\-]{7,}\d)')
@@ -847,6 +933,13 @@ async def report_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """Handle /report command"""
     await handle_report_user(update, context)
 
+
+async def saved_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /saved command"""
+    user_id = update.effective_user.id
+    text, keyboard = build_saved_chat_menu(user_id)
+    await update.message.reply_text(text, reply_markup=keyboard, parse_mode='Markdown')
+
 async def handle_report_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle reporting current partner"""
     user_id = update.effective_user.id
@@ -946,6 +1039,10 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     
     elif data == 'view_profile':
         await show_profile_callback(query, context)
+
+    elif data == 'view_saved_chats':
+        text, keyboard = build_saved_chat_menu(user_id)
+        await query.edit_message_text(text, reply_markup=keyboard, parse_mode='Markdown')
     
     elif data == 'help_menu':
         await query.edit_message_text(
@@ -1009,6 +1106,31 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     
     elif data == 'send_view_once':
         await handle_send_view_once_callback(query, context)
+
+    elif data == 'save_chat':
+        await handle_save_chat_callback(query, context)
+
+    elif data.startswith('save_accept_'):
+        await handle_save_chat_response_callback(query, context, accepted=True)
+
+    elif data.startswith('save_decline_'):
+        await handle_save_chat_response_callback(query, context, accepted=False)
+
+    elif data == 'saved_refresh':
+        text, keyboard = build_saved_chat_menu(user_id)
+        await query.edit_message_text(text, reply_markup=keyboard, parse_mode='Markdown')
+
+    elif data.startswith('saved_reconnect_'):
+        await handle_saved_reconnect_callback(query, context)
+
+    elif data.startswith('saved_delete_'):
+        await handle_saved_delete_callback(query)
+
+    elif data.startswith('reconnect_accept_'):
+        await handle_reconnect_response_callback(query, context, accepted=True)
+
+    elif data.startswith('reconnect_decline_'):
+        await handle_reconnect_response_callback(query, context, accepted=False)
     
     # Creative Features - Games
     elif data == 'games_menu':
@@ -1451,6 +1573,192 @@ async def handle_send_view_once_callback(query, context: ContextTypes.DEFAULT_TY
     context.user_data['sending_view_once'] = True
     context.user_data['photo_partner'] = partner_id
 
+
+async def handle_save_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send save-chat request to current partner"""
+    user_id = query.from_user.id
+    partner_id = matchmaking.get_partner(user_id)
+
+    if not partner_id:
+        await query.answer("❌ You are not in an active chat.", show_alert=True)
+        return
+
+    with database.get_db() as db:
+        current_count = database.count_saved_chats_for_owner(db, user_id)
+        if current_count >= 3:
+            await query.answer(Messages.SAVE_LIMIT_REACHED, show_alert=True)
+            return
+
+        if database.get_saved_chat(db, user_id, partner_id):
+            await query.answer(Messages.SAVE_ALREADY_EXISTS, show_alert=True)
+            return
+
+    await query.answer("💾 Save request sent.")
+    bot_data = context.bot_data if context else query.bot_data
+    pending_save_requests = bot_data.setdefault('pending_save_requests', set())
+    pending_save_requests.add((partner_id, user_id))
+    await context.bot.send_message(user_id, Messages.SAVE_REQUEST_SENT)
+    await context.bot.send_message(
+        partner_id,
+        Messages.SAVE_REQUEST_RECEIVED,
+        reply_markup=Keyboards.save_request_panel(user_id)
+    )
+
+
+async def handle_save_chat_response_callback(query, context: Optional[ContextTypes.DEFAULT_TYPE] = None, accepted: bool = False) -> None:
+    """Handle accept/decline for save-chat request"""
+    if isinstance(context, bool):
+        accepted = context
+        context = None
+
+    responder_id = query.from_user.id
+
+    try:
+        requester_id = int(query.data.rsplit('_', 1)[1])
+    except (ValueError, IndexError):
+        await query.answer("❌ Invalid save request.", show_alert=True)
+        return
+
+    bot_data = context.bot_data if context else query.bot_data
+    pending_save_requests = bot_data.setdefault('pending_save_requests', set())
+    request_key = (responder_id, requester_id)
+
+    if request_key not in pending_save_requests:
+        await query.answer("⚠️ This save request has expired.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(responder_id) != requester_id:
+        pending_save_requests.discard(request_key)
+        await query.answer("⚠️ This save request is no longer valid.", show_alert=True)
+        return
+
+    if not accepted:
+        pending_save_requests.discard(request_key)
+        await query.edit_message_text(Messages.SAVE_DECLINED_PARTNER)
+        await query.bot.send_message(requester_id, Messages.SAVE_DECLINED_SENDER)
+        return
+
+    with database.get_db() as db:
+        requester_count = database.count_saved_chats_for_owner(db, requester_id)
+        responder_count = database.count_saved_chats_for_owner(db, responder_id)
+
+        if requester_count >= 3:
+            pending_save_requests.discard(request_key)
+            await query.edit_message_text("⚠️ Requester reached the saved chat limit (3).")
+            await query.bot.send_message(requester_id, Messages.SAVE_LIMIT_REACHED)
+            return
+
+        if responder_count >= 3:
+            pending_save_requests.discard(request_key)
+            await query.edit_message_text("⚠️ You already have 3 saved chats. Delete one first.")
+            await query.bot.send_message(requester_id, "❌ Partner cannot save now because their list is full.")
+            return
+
+        database.create_saved_chat(db, requester_id, responder_id)
+        database.create_saved_chat(db, responder_id, requester_id)
+
+    pending_save_requests.discard(request_key)
+    await query.edit_message_text(Messages.SAVE_ACCEPTED_PARTNER)
+    await query.bot.send_message(requester_id, Messages.SAVE_ACCEPTED_SENDER)
+
+
+async def handle_saved_delete_callback(query) -> None:
+    """Delete a saved chat entry"""
+    user_id = query.from_user.id
+
+    try:
+        partner_id = int(query.data.replace('saved_delete_', ''))
+    except ValueError:
+        await query.answer("❌ Invalid saved chat.", show_alert=True)
+        return
+
+    with database.get_db() as db:
+        deleted = database.delete_saved_chat(db, user_id, partner_id)
+
+    if deleted:
+        await query.answer("🗑️ Saved chat deleted.")
+    else:
+        await query.answer("⚠️ Saved chat already removed.")
+
+    text, keyboard = build_saved_chat_menu(user_id)
+    await query.edit_message_text(text, reply_markup=keyboard, parse_mode='Markdown')
+
+
+async def handle_saved_reconnect_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Request reconnect with a saved partner"""
+    user_id = query.from_user.id
+
+    try:
+        partner_id = int(query.data.replace('saved_reconnect_', ''))
+    except ValueError:
+        await query.answer("❌ Invalid saved chat.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(user_id) or user_id in matchmaking.waiting_users:
+        await query.answer("⚠️ Finish your current chat/search before reconnecting.", show_alert=True)
+        return
+
+    with database.get_db() as db:
+        saved_chat = database.get_saved_chat(db, user_id, partner_id)
+        if not saved_chat:
+            await query.answer("⚠️ Saved chat not found.", show_alert=True)
+            return
+
+    if matchmaking.get_partner(partner_id) or partner_id in matchmaking.waiting_users:
+        await query.answer("⚠️ Partner is busy right now. Try again later.", show_alert=True)
+        return
+
+    await query.answer("🔁 Reconnect request sent.")
+    await context.bot.send_message(user_id, Messages.RECONNECT_REQUEST_SENT)
+    await context.bot.send_message(
+        partner_id,
+        Messages.RECONNECT_REQUEST_RECEIVED,
+        reply_markup=Keyboards.reconnect_request_panel(user_id)
+    )
+
+
+async def handle_reconnect_response_callback(query, context: ContextTypes.DEFAULT_TYPE, accepted: bool) -> None:
+    """Handle reconnect accept/decline"""
+    responder_id = query.from_user.id
+
+    try:
+        requester_id = int(query.data.rsplit('_', 1)[1])
+    except (ValueError, IndexError):
+        await query.answer("❌ Invalid reconnect request.", show_alert=True)
+        return
+
+    if not accepted:
+        await query.edit_message_text(Messages.RECONNECT_DECLINED_PARTNER)
+        await query.bot.send_message(requester_id, Messages.RECONNECT_DECLINED_SENDER)
+        return
+
+    if matchmaking.get_partner(responder_id) or responder_id in matchmaking.waiting_users:
+        await query.answer("⚠️ You are currently busy.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(requester_id) or requester_id in matchmaking.waiting_users:
+        await query.edit_message_text("⚠️ Requester is no longer available.")
+        await query.bot.send_message(requester_id, "⚠️ Reconnect failed because you are busy now.")
+        return
+
+    with database.get_db() as db:
+        requester_saved = database.get_saved_chat(db, requester_id, responder_id)
+        responder_saved = database.get_saved_chat(db, responder_id, requester_id)
+        if not requester_saved or not responder_saved:
+            await query.edit_message_text("⚠️ Saved chat link no longer exists.")
+            await query.bot.send_message(requester_id, "⚠️ Reconnect failed because saved chat was removed.")
+            return
+
+    connected = await matchmaking.connect_saved_partners(requester_id, responder_id)
+    if not connected:
+        await query.edit_message_text("⚠️ Reconnect failed because one user is busy now.")
+        await query.bot.send_message(requester_id, "⚠️ Reconnect failed because one user is busy now.")
+        return
+
+    await query.edit_message_text(Messages.RECONNECT_ACCEPTED)
+    await query.bot.send_message(requester_id, Messages.RECONNECT_ACCEPTED, reply_markup=Keyboards.chat_controls())
+    await query.bot.send_message(responder_id, Messages.RECONNECT_ACCEPTED, reply_markup=Keyboards.chat_controls())
+
 async def handle_skip_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle skip chat button callback"""
     user_id = query.from_user.id
@@ -1671,17 +1979,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await handle_profile_editing(update, context, editing_state)
         return
     
-    # Check if user is searching - block commands during search
-    if user_id in matchmaking.waiting_users:
-        await update.message.reply_text(
-            "🔍 You're currently searching for a partner. Please use the search control buttons or stop your search to use commands."
-        )
-        return
-    
     # Check if user is in chat
     partner_id = matchmaking.get_partner(user_id)
-    
+
     if partner_id:
+        if user_id in matchmaking.waiting_users:
+            matchmaking.waiting_users.discard(user_id)
         # Forward message to partner with content warning if needed
         if contains_inappropriate_content(message_text):
             await update.message.reply_text(Messages.WARNING_MESSAGE, parse_mode='Markdown')
@@ -1701,6 +2004,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             logger.error(f"Failed to forward message: {e}")
             await update.message.reply_text("❌ Failed to send message. Your partner may have left.")
     else:
+        if user_id in matchmaking.waiting_users:
+            await update.message.reply_text(
+                "🔍 You're currently searching for a partner. Please use the search control buttons or stop your search to use commands."
+            )
+            return
+
         # User not in chat - show main menu
         with database.get_db() as db:
             user = database.get_user(db, user_id)
@@ -1970,6 +2279,63 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 reply_markup=Keyboards.main_menu()
             )
 
+async def handle_video(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle video messages"""
+    if not update.message or not update.message.video:
+        return
+
+    user_id = update.effective_user.id
+    partner_id = matchmaking.get_partner(user_id)
+
+    if partner_id:
+        try:
+            await context.bot.send_video(
+                partner_id,
+                update.message.video.file_id,
+                caption="🎬 Your chat partner sent you a video!",
+                protect_content=True
+            )
+        except TelegramError as e:
+            logger.error(f"Failed to forward video: {e}")
+            await update.message.reply_text("❌ Failed to send video. Your partner may have left.")
+    else:
+        await update.message.reply_text(
+            "🎬 To send videos, you need to be in an active chat.",
+            reply_markup=Keyboards.main_menu()
+        )
+
+
+async def handle_video_document(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle MP4 files sent as documents"""
+    if not update.message or not update.message.document:
+        return
+
+    mime_type = (update.message.document.mime_type or '').lower()
+    file_name = (update.message.document.file_name or '').lower()
+    if mime_type != 'video/mp4' and not file_name.endswith('.mp4'):
+        return
+
+    user_id = update.effective_user.id
+    partner_id = matchmaking.get_partner(user_id)
+
+    if partner_id:
+        try:
+            await context.bot.send_document(
+                partner_id,
+                update.message.document.file_id,
+                caption="🎬 Your chat partner sent you an MP4 video file!",
+                protect_content=True
+            )
+        except TelegramError as e:
+            logger.error(f"Failed to forward MP4 document: {e}")
+            await update.message.reply_text("❌ Failed to send MP4. Your partner may have left.")
+    else:
+        await update.message.reply_text(
+            "🎬 To send MP4 files, you need to be in an active chat.",
+            reply_markup=Keyboards.main_menu()
+        )
+
+
 async def handle_sticker(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle sticker messages"""
     if not update.message or not update.message.sticker:
@@ -2110,6 +2476,7 @@ def main() -> None:
     application.add_handler(CommandHandler("skip", skip_command))
     application.add_handler(CommandHandler("stop", stop_command))
     application.add_handler(CommandHandler("report", report_command))
+    application.add_handler(CommandHandler("saved", saved_command))
     application.add_handler(CommandHandler("profile", profile_command))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("privacy", privacy_command))
@@ -2118,6 +2485,8 @@ def main() -> None:
     
     application.add_handler(CallbackQueryHandler(button_callback))
     application.add_handler(MessageHandler(filters.PHOTO, handle_photo))
+    application.add_handler(MessageHandler(filters.VIDEO, handle_video))
+    application.add_handler(MessageHandler(filters.Document.MimeType("video/mp4"), handle_video_document))
     application.add_handler(MessageHandler(filters.Sticker.ALL, handle_sticker))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, block_personal_info),group=0)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
@@ -2129,6 +2498,7 @@ def main() -> None:
             BotCommand("find", "Find a chat partner"),
             BotCommand("skip", "Skip current chat partner"),
             BotCommand("stop", "End current chat"),
+            BotCommand("saved", "View saved chats"),
             BotCommand("profile", "View/edit your profile"),
             BotCommand("viewonce", "Send a view-once disappearing photo"),
             BotCommand("help", "Show help menu"),

--- a/database.py
+++ b/database.py
@@ -121,6 +121,18 @@ class BroadcastMessage(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     completed_at = Column(DateTime, nullable=True)
 
+
+class SavedChat(Base):
+    __tablename__ = 'saved_chats'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    owner_id = Column(BigInteger, ForeignKey('users.user_id'), nullable=False)
+    partner_id = Column(BigInteger, ForeignKey('users.user_id'), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    owner = relationship("User", foreign_keys=[owner_id])
+    partner = relationship("User", foreign_keys=[partner_id])
+
 @contextmanager
 def get_db():
     """Database session context manager"""
@@ -167,6 +179,114 @@ def init_database():
                     pass  # Column might already exist or other issue
             
             logger.info("Database migration completed successfully")
+
+            # Create or migrate saved chats table
+            try:
+                conn.execute(text(
+                    """
+                    CREATE TABLE IF NOT EXISTS saved_chats (
+                        id SERIAL PRIMARY KEY,
+                        owner_id BIGINT,
+                        partner_id BIGINT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                ))
+                conn.commit()
+
+                saved_chat_columns = {
+                    row[0]
+                    for row in conn.execute(text(
+                        "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'saved_chats'"
+                    ))
+                }
+
+                if 'owner_id' not in saved_chat_columns:
+                    conn.execute(text("ALTER TABLE saved_chats ADD COLUMN owner_id BIGINT"))
+                    conn.commit()
+                    if 'user_id' in saved_chat_columns:
+                        conn.execute(text("UPDATE saved_chats SET owner_id = user_id WHERE owner_id IS NULL"))
+                        conn.commit()
+
+                if 'partner_id' not in saved_chat_columns:
+                    conn.execute(text("ALTER TABLE saved_chats ADD COLUMN partner_id BIGINT"))
+                    conn.commit()
+                    if 'partner_user_id' in saved_chat_columns:
+                        conn.execute(text("UPDATE saved_chats SET partner_id = partner_user_id WHERE partner_id IS NULL"))
+                        conn.commit()
+
+                if 'user_id' in saved_chat_columns and 'owner_id' in saved_chat_columns:
+                    conn.execute(text("UPDATE saved_chats SET user_id = owner_id WHERE user_id IS NULL AND owner_id IS NOT NULL"))
+                    conn.commit()
+
+                if 'partner_user_id' in saved_chat_columns and 'partner_id' in saved_chat_columns:
+                    conn.execute(text("UPDATE saved_chats SET partner_user_id = partner_id WHERE partner_user_id IS NULL AND partner_id IS NOT NULL"))
+                    conn.commit()
+
+                conn.execute(text("ALTER TABLE saved_chats ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"))
+                conn.execute(text("DELETE FROM saved_chats WHERE owner_id IS NULL OR partner_id IS NULL"))
+                conn.commit()
+
+                try:
+                    conn.execute(text("ALTER TABLE saved_chats ALTER COLUMN owner_id SET NOT NULL"))
+                    conn.execute(text("ALTER TABLE saved_chats ALTER COLUMN partner_id SET NOT NULL"))
+                    conn.commit()
+                except Exception as not_null_error:
+                    logger.warning(f"Saved chats NOT NULL migration warning: {not_null_error}")
+                    conn.rollback()
+
+                conn.execute(text("CREATE INDEX IF NOT EXISTS idx_saved_chats_owner_id ON saved_chats(owner_id)"))
+                conn.execute(text("CREATE UNIQUE INDEX IF NOT EXISTS uq_saved_chats_owner_partner ON saved_chats(owner_id, partner_id)"))
+                conn.commit()
+
+                try:
+                    conn.execute(text(
+                        """
+                        DO $$
+                        BEGIN
+                            IF NOT EXISTS (
+                                SELECT 1
+                                FROM pg_constraint
+                                WHERE conname = 'fk_saved_chats_owner_id'
+                            ) THEN
+                                ALTER TABLE saved_chats
+                                ADD CONSTRAINT fk_saved_chats_owner_id
+                                FOREIGN KEY (owner_id) REFERENCES users(user_id) ON DELETE CASCADE;
+                            END IF;
+                        END
+                        $$;
+                        """
+                    ))
+                    conn.commit()
+                except Exception as owner_fk_error:
+                    logger.warning(f"Saved chats owner FK migration warning: {owner_fk_error}")
+                    conn.rollback()
+
+                try:
+                    conn.execute(text(
+                        """
+                        DO $$
+                        BEGIN
+                            IF NOT EXISTS (
+                                SELECT 1
+                                FROM pg_constraint
+                                WHERE conname = 'fk_saved_chats_partner_id'
+                            ) THEN
+                                ALTER TABLE saved_chats
+                                ADD CONSTRAINT fk_saved_chats_partner_id
+                                FOREIGN KEY (partner_id) REFERENCES users(user_id) ON DELETE CASCADE;
+                            END IF;
+                        END
+                        $$;
+                        """
+                    ))
+                    conn.commit()
+                except Exception as partner_fk_error:
+                    logger.warning(f"Saved chats partner FK migration warning: {partner_fk_error}")
+                    conn.rollback()
+            except Exception as migration_error:
+                logger.error(f"Saved chats migration failed: {migration_error}")
+                conn.rollback()
     except Exception as e:
         logger.error(f"Failed to create database tables: {e}")
         raise
@@ -408,3 +528,140 @@ def update_broadcast_stats(db, broadcast_id: int, sent_count: int, failed_count:
         broadcast.failed_count = failed_count
         broadcast.completed_at = datetime.utcnow()
         db.flush()
+
+
+def _get_saved_chat_columns(db):
+    """Detect saved_chats owner/partner column names for legacy compatibility"""
+    rows = db.execute(text(
+        "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'saved_chats'"
+    )).fetchall()
+    columns = {row[0] for row in rows}
+
+    owner_col = 'owner_id' if 'owner_id' in columns else 'user_id' if 'user_id' in columns else None
+    partner_col = 'partner_id' if 'partner_id' in columns else 'partner_user_id' if 'partner_user_id' in columns else None
+    return owner_col, partner_col
+
+
+def _get_saved_chat_column_set(db) -> Set[str]:
+    """Get all columns currently present in saved_chats table"""
+    rows = db.execute(text(
+        "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'saved_chats'"
+    )).fetchall()
+    return {row[0] for row in rows}
+
+
+def get_saved_chat(db, owner_id: int, partner_id: int) -> Optional[SavedChat]:
+    """Get one saved chat for owner and partner"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return None
+
+    query = text(
+        f"SELECT id, {owner_col} AS owner_id, {partner_col} AS partner_id, created_at FROM saved_chats "
+        f"WHERE {owner_col} = :owner_id AND {partner_col} = :partner_id LIMIT 1"
+    )
+    row = db.execute(query, {'owner_id': owner_id, 'partner_id': partner_id}).fetchone()
+    if not row:
+        return None
+
+    record = SavedChat()
+    record.id = row[0]
+    record.owner_id = row[1]
+    record.partner_id = row[2]
+    record.created_at = row[3]
+    return record
+
+
+def get_saved_chats_for_owner(db, owner_id: int) -> List[SavedChat]:
+    """Get all saved chats for one owner"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return []
+
+    query = text(
+        f"SELECT id, {owner_col} AS owner_id, {partner_col} AS partner_id, created_at FROM saved_chats "
+        f"WHERE {owner_col} = :owner_id ORDER BY created_at DESC"
+    )
+    rows = db.execute(query, {'owner_id': owner_id}).fetchall()
+
+    results = []
+    for row in rows:
+        record = SavedChat()
+        record.id = row[0]
+        record.owner_id = row[1]
+        record.partner_id = row[2]
+        record.created_at = row[3]
+        results.append(record)
+    return results
+
+
+def count_saved_chats_for_owner(db, owner_id: int) -> int:
+    """Count saved chats for one owner"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return 0
+
+    query = text(f"SELECT COUNT(*) FROM saved_chats WHERE {owner_col} = :owner_id")
+    return db.execute(query, {'owner_id': owner_id}).scalar() or 0
+
+
+def create_saved_chat(db, owner_id: int, partner_id: int) -> Optional[SavedChat]:
+    """Create a saved chat if it does not exist"""
+    existing = get_saved_chat(db, owner_id, partner_id)
+    if existing:
+        return existing
+
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return None
+
+    columns = _get_saved_chat_column_set(db)
+    insert_fields = [owner_col, partner_col]
+    params = {
+        'owner_id': owner_id,
+        'partner_id': partner_id,
+    }
+
+    if 'user_id' in columns and 'user_id' not in insert_fields:
+        insert_fields.append('user_id')
+        params['user_id'] = owner_id
+
+    if 'partner_user_id' in columns and 'partner_user_id' not in insert_fields:
+        insert_fields.append('partner_user_id')
+        params['partner_user_id'] = partner_id
+
+    values_clause = []
+    for field in insert_fields:
+        if field == owner_col:
+            values_clause.append(':owner_id')
+        elif field == partner_col:
+            values_clause.append(':partner_id')
+        else:
+            values_clause.append(f':{field}')
+
+    insert_query = text(
+        f"INSERT INTO saved_chats ({', '.join(insert_fields)}) VALUES ({', '.join(values_clause)}) RETURNING id, created_at"
+    )
+    row = db.execute(insert_query, params).fetchone()
+    if not row:
+        return None
+
+    record = SavedChat()
+    record.id = row[0]
+    record.owner_id = owner_id
+    record.partner_id = partner_id
+    record.created_at = row[1]
+    return record
+
+
+def delete_saved_chat(db, owner_id: int, partner_id: int) -> bool:
+    """Delete one saved chat"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return False
+
+    delete_query = text(
+        f"DELETE FROM saved_chats WHERE {owner_col} = :owner_id AND {partner_col} = :partner_id"
+    )
+    result = db.execute(delete_query, {'owner_id': owner_id, 'partner_id': partner_id})
+    return result.rowcount > 0


### PR DESCRIPTION
### Motivation
- Production logs showed repeated `NOT NULL` violations on `saved_chats.user_id` when inserts only provided `owner_id`/`partner_id`. 
- The codebase needs to support mixed/legacy Railway schemas where alias columns (`user_id` / `partner_user_id`) may still exist and be constrained NOT NULL. 
- In addition, the bot lacked a user-facing saved-chat experience, so saved-chat persistence and UI flows were added to meet product expectations.

### Description
- Add `SavedChat` ORM model and robust migration code that creates/migrates `saved_chats`, creates indexes and FK constraints, and backfills alias columns so legacy NOT NULL constraints are not violated. 
- Introduce `_get_saved_chat_columns` and `_get_saved_chat_column_set` helpers and update `create_saved_chat` to detect present columns and insert into all required alias columns (e.g. `owner_id` + `user_id`, `partner_id` + `partner_user_id`) in a single `INSERT`. 
- Implement saved-chat features in the bot (`anonymous_chat_bot.py`): new message strings, keyboard items, `/saved` command, save request/accept/decline flows, delete and reconnect flows, and a `build_saved_chat_menu` view for users. 
- Add matchmaking helper `connect_saved_partners`, add handlers for saved-chat callbacks, and small UX improvements including video/MP4 handlers and waiting-queue safeguards when reconnecting.

### Testing
- Ran `python -m py_compile anonymous_chat_bot.py database.py` and compilation completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922462e9908322a5c55512741e3306)