### PR TITLE
Fix Railway polling conflict and restore saved-chats & message forwarding

### DIFF
--- a/anonymous_chat_bot.py
+++ b/anonymous_chat_bot.py
@@ -4,6 +4,7 @@ import asyncio
 import time
 import random
 import re
+import hashlib
 from datetime import datetime, timedelta
 from typing import Dict, List, Set, Optional, Union
 
@@ -43,6 +44,35 @@ TOKEN = os.getenv('TELEGRAM_BOT_TOKEN')
 ADMIN_ID = 1395596220  # Fixed admin ID
 RETRY_MATCHING_INTERVAL = 10  # seconds between matching retries
 MAX_RETRY_ATTEMPTS = 12  # Maximum retry attempts (2 minutes)
+
+POLLER_LOCK_CONNECTION = None
+
+
+def acquire_polling_lock() -> bool:
+    """Ensure only one Railway replica consumes getUpdates"""
+    global POLLER_LOCK_CONNECTION
+    try:
+        dialect_name = getattr(database.engine, 'dialect', None)
+        dialect_name = dialect_name.name if dialect_name else ''
+        if dialect_name != 'postgresql':
+            return True
+
+        lock_key_source = f"anon-chat-bot:{os.getenv('RAILWAY_PROJECT_ID', 'default')}:{os.getenv('RAILWAY_SERVICE_ID', 'default')}"
+        lock_key = int(hashlib.sha1(lock_key_source.encode('utf-8')).hexdigest()[:15], 16)
+
+        conn = database.engine.connect()
+        got_lock = conn.execute(database.text("SELECT pg_try_advisory_lock(:key)"), {'key': lock_key}).scalar()
+        if got_lock:
+            POLLER_LOCK_CONNECTION = conn
+            logger.info("Acquired polling lock for this replica")
+            return True
+
+        conn.close()
+        logger.warning("Another replica is already polling Telegram updates; this replica will stay idle")
+        return False
+    except Exception as lock_error:
+        logger.warning(f"Polling lock check failed, continuing without lock: {lock_error}")
+        return True
 
 if not TOKEN:
     logger.error("TELEGRAM_BOT_TOKEN environment variable not set")
@@ -218,6 +248,21 @@ Your profile is ready! Use the menu below to start chatting or customize your pr
 📅 **Member Since:** {}"""
     
     WARNING_MESSAGE = "⚠️ **Content Warning**\n\nYour message may contain inappropriate content. Please be respectful in your conversations."
+    SAVE_REQUEST_SENT = "💾 Save request sent to your partner. Waiting for response."
+    SAVE_REQUEST_RECEIVED = "💾 Your partner wants to save this chat. Accept?"
+    SAVE_ACCEPTED_SENDER = "✅ Your partner accepted. Chat saved successfully."
+    SAVE_ACCEPTED_PARTNER = "✅ You accepted. This chat has been saved."
+    SAVE_DECLINED_SENDER = "❌ Your partner declined the save request."
+    SAVE_DECLINED_PARTNER = "❌ You declined the save request."
+    SAVE_LIMIT_REACHED = "⚠️ You already have 3 saved chats. Delete one from /saved before saving a new chat."
+    SAVE_ALREADY_EXISTS = "ℹ️ This chat is already saved in your list."
+    SAVED_EMPTY = "📭 You do not have any saved chats yet."
+    SAVED_MENU_TITLE = "💾 **Your Saved Chats**\n\nMaximum saved chats: 3"
+    RECONNECT_REQUEST_SENT = "🔁 Reconnect request sent. Waiting for your saved partner response."
+    RECONNECT_REQUEST_RECEIVED = "🔁 Your saved chat partner wants to reconnect now. Accept?"
+    RECONNECT_ACCEPTED = "✅ Reconnected with your saved partner."
+    RECONNECT_DECLINED_SENDER = "❌ Your saved partner declined the reconnect request."
+    RECONNECT_DECLINED_PARTNER = "❌ You declined the reconnect request."
     
     HELP_MENU = """❓ **Help & Commands**
 
@@ -238,6 +283,7 @@ Your profile is ready! Use the menu below to start chatting or customize your pr
 
 👤 **Profile:**
 • `/profile` - View/edit your profile
+• `/saved` - View your saved chat list
 • `/interests` - Set your interests
 • 😊 Set Mood - Show your current vibe
 
@@ -437,6 +483,7 @@ class Keyboards:
     def main_menu():
         return InlineKeyboardMarkup([
             [InlineKeyboardButton("💬 Find Partner", callback_data='find_partner')],
+            [InlineKeyboardButton("💾 Saved Chats", callback_data='view_saved_chats')],
             [InlineKeyboardButton("👤 My Profile", callback_data='view_profile'), 
              InlineKeyboardButton("❓ Help", callback_data='help_menu')],
             [InlineKeyboardButton("🔒 Privacy", callback_data='privacy_info')]
@@ -447,11 +494,33 @@ class Keyboards:
         return InlineKeyboardMarkup([
             [InlineKeyboardButton("🎁 Send Gift", callback_data='send_gift'),
              InlineKeyboardButton("💬 Compliment", callback_data='send_compliment')],
+            [InlineKeyboardButton("💾 Save Chat", callback_data='save_chat')],
             [InlineKeyboardButton("👤 View Profile", callback_data='view_partner_profile')],
             [InlineKeyboardButton("⏭️ Skip", callback_data='skip_chat'),
              InlineKeyboardButton("🛑 End", callback_data='end_chat')],
             [InlineKeyboardButton("🚨 Report", callback_data='report_user')]
         ])
+
+    @staticmethod
+    def save_request_panel(requester_id: int):
+        return InlineKeyboardMarkup([
+            [InlineKeyboardButton("✅ Accept", callback_data=f'save_accept_{requester_id}'),
+             InlineKeyboardButton("❌ Decline", callback_data=f'save_decline_{requester_id}')]
+        ])
+
+    @staticmethod
+    def reconnect_request_panel(requester_id: int):
+        return InlineKeyboardMarkup([
+            [InlineKeyboardButton("✅ Accept", callback_data=f'reconnect_accept_{requester_id}'),
+             InlineKeyboardButton("❌ Decline", callback_data=f'reconnect_decline_{requester_id}')]
+        ])
+
+    @staticmethod
+    def saved_chat_row(partner_id: int):
+        return [
+            InlineKeyboardButton("🔁 Reconnect", callback_data=f'saved_reconnect_{partner_id}'),
+            InlineKeyboardButton("🗑️ Delete", callback_data=f'saved_delete_{partner_id}')
+        ]
     
     @staticmethod
     def games_menu():
@@ -498,6 +567,7 @@ class Keyboards:
             [InlineKeyboardButton("✏️ Edit Profile", callback_data='edit_profile')],
             [InlineKeyboardButton("💭 Set Interests", callback_data='set_interests')],
             [InlineKeyboardButton("😊 Set Mood", callback_data='set_mood')],
+            [InlineKeyboardButton("💾 Saved Chats", callback_data='view_saved_chats')],
             [InlineKeyboardButton("🌐 Language", callback_data='change_language')],
             [InlineKeyboardButton("🔙 Back to Menu", callback_data='main_menu')]
         ])
@@ -648,8 +718,37 @@ class MatchmakingService:
                 del self.retry_tasks[user_id]
     
     def get_partner(self, user_id: int) -> Optional[int]:
-        """Get current chat partner"""
-        return self.active_sessions.get(user_id)
+        """Get current chat partner and repair one-sided mappings if needed"""
+        partner_id = self.active_sessions.get(user_id)
+        if partner_id:
+            return partner_id
+
+        for candidate_id, candidate_partner in list(self.active_sessions.items()):
+            if candidate_partner == user_id:
+                self.active_sessions[user_id] = candidate_id
+                return candidate_id
+
+        return None
+
+    async def connect_saved_partners(self, user_a_id: int, user_b_id: int) -> bool:
+        """Create active session for saved partners safely"""
+        async with self.lock:
+            if user_a_id in self.active_sessions or user_b_id in self.active_sessions:
+                return False
+            if user_a_id in self.waiting_users or user_b_id in self.waiting_users:
+                return False
+
+            for uid in [user_a_id, user_b_id]:
+                if uid in self.retry_tasks:
+                    self.retry_tasks[uid].cancel()
+                    del self.retry_tasks[uid]
+
+            self.active_sessions[user_a_id] = user_b_id
+            self.active_sessions[user_b_id] = user_a_id
+
+            with database.get_db() as db:
+                database.create_chat_session(db, user_a_id, user_b_id)
+            return True
     
     async def start_matching_with_retry(self, user_id: int, context: ContextTypes.DEFAULT_TYPE):
         """Start matching process with retry logic"""
@@ -708,6 +807,44 @@ def contains_inappropriate_content(text: str) -> bool:
         if re.search(pattern, text.lower()):
             return True
     return False
+
+
+def build_saved_chat_menu(user_id: int):
+    """Build saved chat text and panel"""
+    with database.get_db() as db:
+        saved_chats = database.get_saved_chats_for_owner(db, user_id)
+
+        if not saved_chats:
+            return Messages.SAVED_EMPTY, Keyboards.main_menu()
+
+        lines = ["💾 Your Saved Chats", "", "Maximum saved chats: 3", ""]
+        buttons = []
+
+        for index, saved_chat in enumerate(saved_chats, start=1):
+            partner = database.get_user(db, saved_chat.partner_id)
+            partner_name = partner.nickname if partner else f"User {saved_chat.partner_id}"
+            if saved_chat.created_at:
+                saved_date = saved_chat.created_at.strftime('%Y-%m-%d %H:%M')
+            else:
+                saved_date = "Unknown"
+            lines.append(f"{index}. **{partner_name}**")
+            lines.append(f"   🆔 `{saved_chat.partner_id}`")
+            lines.append(f"   📅 Saved at: {saved_date}")
+            lines.append("")
+            buttons.append(Keyboards.saved_chat_row(saved_chat.partner_id))
+
+        buttons.append([InlineKeyboardButton("🔄 Refresh", callback_data='saved_refresh')])
+        buttons.append([InlineKeyboardButton("🏠 Main Menu", callback_data='main_menu')])
+        return "\n".join(lines).strip(), InlineKeyboardMarkup(buttons)
+
+
+def get_bot_from_callback(query, context: Optional[ContextTypes.DEFAULT_TYPE] = None):
+    """Safely resolve bot instance in callback handlers"""
+    if context and getattr(context, 'bot', None):
+        return context.bot
+    if query and getattr(query, 'message', None):
+        return query.message.get_bot()
+    return None
     
 USERNAME_PATTERN = re.compile(r'@\w+')
 PHONE_PATTERN = re.compile(r'(\+?\d[\d\s\-]{7,}\d)')
@@ -847,6 +984,13 @@ async def report_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """Handle /report command"""
     await handle_report_user(update, context)
 
+
+async def saved_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /saved command"""
+    user_id = update.effective_user.id
+    text, keyboard = build_saved_chat_menu(user_id)
+    await update.message.reply_text(text, reply_markup=keyboard)
+
 async def handle_report_user(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle reporting current partner"""
     user_id = update.effective_user.id
@@ -886,7 +1030,7 @@ async def show_profile(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             return
         
         interests = ", ".join([interest.name for interest in user.interests]) if user.interests else "None set"
-        created_date = user.created_at.strftime("%B %d, %Y")
+        created_date = user.created_at.strftime("%B %d, %Y") if user.created_at else "Unknown"
         mood_display = f"{user.mood} {Moods.OPTIONS.get(user.mood, '')}" if user.mood else "Not set"
         
         profile_text = Messages.PROFILE_INFO.format(
@@ -946,6 +1090,10 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     
     elif data == 'view_profile':
         await show_profile_callback(query, context)
+
+    elif data == 'view_saved_chats':
+        text, keyboard = build_saved_chat_menu(user_id)
+        await query.edit_message_text(text, reply_markup=keyboard)
     
     elif data == 'help_menu':
         await query.edit_message_text(
@@ -1009,6 +1157,31 @@ async def button_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     
     elif data == 'send_view_once':
         await handle_send_view_once_callback(query, context)
+
+    elif data == 'save_chat':
+        await handle_save_chat_callback(query, context)
+
+    elif data.startswith('save_accept_'):
+        await handle_save_chat_response_callback(query, context, accepted=True)
+
+    elif data.startswith('save_decline_'):
+        await handle_save_chat_response_callback(query, context, accepted=False)
+
+    elif data == 'saved_refresh':
+        text, keyboard = build_saved_chat_menu(user_id)
+        await query.edit_message_text(text, reply_markup=keyboard)
+
+    elif data.startswith('saved_reconnect_'):
+        await handle_saved_reconnect_callback(query, context)
+
+    elif data.startswith('saved_delete_'):
+        await handle_saved_delete_callback(query)
+
+    elif data.startswith('reconnect_accept_'):
+        await handle_reconnect_response_callback(query, context, accepted=True)
+
+    elif data.startswith('reconnect_decline_'):
+        await handle_reconnect_response_callback(query, context, accepted=False)
     
     # Creative Features - Games
     elif data == 'games_menu':
@@ -1270,7 +1443,7 @@ async def show_profile_callback(query, context: ContextTypes.DEFAULT_TYPE) -> No
             return
         
         interests = ", ".join([interest.name for interest in user.interests]) if user.interests else "None set"
-        created_date = user.created_at.strftime("%B %d, %Y")
+        created_date = user.created_at.strftime("%B %d, %Y") if user.created_at else "Unknown"
         mood_display = f"{user.mood} {Moods.OPTIONS.get(user.mood, '')}" if user.mood else "Not set"
         
         profile_text = Messages.PROFILE_INFO.format(
@@ -1451,6 +1624,210 @@ async def handle_send_view_once_callback(query, context: ContextTypes.DEFAULT_TY
     context.user_data['sending_view_once'] = True
     context.user_data['photo_partner'] = partner_id
 
+
+async def handle_save_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send save-chat request to current partner"""
+    user_id = query.from_user.id
+    partner_id = matchmaking.get_partner(user_id)
+
+    if not partner_id:
+        await query.answer("❌ You are not in an active chat.", show_alert=True)
+        return
+
+    with database.get_db() as db:
+        current_count = database.count_saved_chats_for_owner(db, user_id)
+        if current_count >= 3:
+            await query.answer(Messages.SAVE_LIMIT_REACHED, show_alert=True)
+            return
+
+        if database.get_saved_chat(db, user_id, partner_id):
+            await query.answer(Messages.SAVE_ALREADY_EXISTS, show_alert=True)
+            return
+
+    await query.answer("💾 Save request sent.")
+    bot_data = context.bot_data if context else query.bot_data
+    pending_save_requests = bot_data.setdefault('pending_save_requests', set())
+    pending_save_requests.add((partner_id, user_id))
+    await context.bot.send_message(user_id, Messages.SAVE_REQUEST_SENT)
+    await context.bot.send_message(
+        partner_id,
+        Messages.SAVE_REQUEST_RECEIVED,
+        reply_markup=Keyboards.save_request_panel(user_id)
+    )
+
+
+async def handle_save_chat_response_callback(query, context: Optional[ContextTypes.DEFAULT_TYPE] = None, accepted: bool = False) -> None:
+    """Handle accept/decline for save-chat request"""
+    if isinstance(context, bool):
+        accepted = context
+        context = None
+
+    responder_id = query.from_user.id
+
+    try:
+        requester_id = int(query.data.rsplit('_', 1)[1])
+    except (ValueError, IndexError):
+        await query.answer("❌ Invalid save request.", show_alert=True)
+        return
+
+    bot_data = context.bot_data if context else query.bot_data
+    pending_save_requests = bot_data.setdefault('pending_save_requests', set())
+    request_key = (responder_id, requester_id)
+
+    if request_key not in pending_save_requests:
+        await query.answer("⚠️ This save request has expired.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(responder_id) != requester_id:
+        pending_save_requests.discard(request_key)
+        await query.answer("⚠️ This save request is no longer valid.", show_alert=True)
+        return
+
+    if not accepted:
+        pending_save_requests.discard(request_key)
+        await query.edit_message_text(Messages.SAVE_DECLINED_PARTNER)
+        bot = get_bot_from_callback(query, context)
+        if bot:
+            await bot.send_message(requester_id, Messages.SAVE_DECLINED_SENDER)
+        return
+
+    with database.get_db() as db:
+        requester_count = database.count_saved_chats_for_owner(db, requester_id)
+        responder_count = database.count_saved_chats_for_owner(db, responder_id)
+
+        if requester_count >= 3:
+            pending_save_requests.discard(request_key)
+            await query.edit_message_text("⚠️ Requester reached the saved chat limit (3).")
+            bot = get_bot_from_callback(query, context)
+            if bot:
+                await bot.send_message(requester_id, Messages.SAVE_LIMIT_REACHED)
+            return
+
+        if responder_count >= 3:
+            pending_save_requests.discard(request_key)
+            await query.edit_message_text("⚠️ You already have 3 saved chats. Delete one first.")
+            bot = get_bot_from_callback(query, context)
+            if bot:
+                await bot.send_message(requester_id, "❌ Partner cannot save now because their list is full.")
+            return
+
+        database.create_saved_chat(db, requester_id, responder_id)
+        database.create_saved_chat(db, responder_id, requester_id)
+
+    pending_save_requests.discard(request_key)
+    await query.edit_message_text(Messages.SAVE_ACCEPTED_PARTNER)
+    bot = get_bot_from_callback(query, context)
+    if bot:
+        await bot.send_message(requester_id, Messages.SAVE_ACCEPTED_SENDER)
+
+
+async def handle_saved_delete_callback(query) -> None:
+    """Delete a saved chat entry"""
+    user_id = query.from_user.id
+
+    try:
+        partner_id = int(query.data.replace('saved_delete_', ''))
+    except ValueError:
+        await query.answer("❌ Invalid saved chat.", show_alert=True)
+        return
+
+    with database.get_db() as db:
+        deleted = database.delete_saved_chat(db, user_id, partner_id)
+
+    if deleted:
+        await query.answer("🗑️ Saved chat deleted.")
+    else:
+        await query.answer("⚠️ Saved chat already removed.")
+
+    text, keyboard = build_saved_chat_menu(user_id)
+    await query.edit_message_text(text, reply_markup=keyboard)
+
+
+async def handle_saved_reconnect_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Request reconnect with a saved partner"""
+    user_id = query.from_user.id
+
+    try:
+        partner_id = int(query.data.replace('saved_reconnect_', ''))
+    except ValueError:
+        await query.answer("❌ Invalid saved chat.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(user_id) or user_id in matchmaking.waiting_users:
+        await query.answer("⚠️ Finish your current chat/search before reconnecting.", show_alert=True)
+        return
+
+    with database.get_db() as db:
+        saved_chat = database.get_saved_chat(db, user_id, partner_id)
+        if not saved_chat:
+            await query.answer("⚠️ Saved chat not found.", show_alert=True)
+            return
+
+    if matchmaking.get_partner(partner_id) or partner_id in matchmaking.waiting_users:
+        await query.answer("⚠️ Partner is busy right now. Try again later.", show_alert=True)
+        return
+
+    await query.answer("🔁 Reconnect request sent.")
+    await context.bot.send_message(user_id, Messages.RECONNECT_REQUEST_SENT)
+    await context.bot.send_message(
+        partner_id,
+        Messages.RECONNECT_REQUEST_RECEIVED,
+        reply_markup=Keyboards.reconnect_request_panel(user_id)
+    )
+
+
+async def handle_reconnect_response_callback(query, context: ContextTypes.DEFAULT_TYPE, accepted: bool) -> None:
+    """Handle reconnect accept/decline"""
+    responder_id = query.from_user.id
+
+    try:
+        requester_id = int(query.data.rsplit('_', 1)[1])
+    except (ValueError, IndexError):
+        await query.answer("❌ Invalid reconnect request.", show_alert=True)
+        return
+
+    if not accepted:
+        await query.edit_message_text(Messages.RECONNECT_DECLINED_PARTNER)
+        bot = get_bot_from_callback(query, context)
+        if bot:
+            await bot.send_message(requester_id, Messages.RECONNECT_DECLINED_SENDER)
+        return
+
+    if matchmaking.get_partner(responder_id) or responder_id in matchmaking.waiting_users:
+        await query.answer("⚠️ You are currently busy.", show_alert=True)
+        return
+
+    if matchmaking.get_partner(requester_id) or requester_id in matchmaking.waiting_users:
+        await query.edit_message_text("⚠️ Requester is no longer available.")
+        bot = get_bot_from_callback(query, context)
+        if bot:
+            await bot.send_message(requester_id, "⚠️ Reconnect failed because you are busy now.")
+        return
+
+    with database.get_db() as db:
+        requester_saved = database.get_saved_chat(db, requester_id, responder_id)
+        responder_saved = database.get_saved_chat(db, responder_id, requester_id)
+        if not requester_saved or not responder_saved:
+            await query.edit_message_text("⚠️ Saved chat link no longer exists.")
+            bot = get_bot_from_callback(query, context)
+            if bot:
+                await bot.send_message(requester_id, "⚠️ Reconnect failed because saved chat was removed.")
+            return
+
+    connected = await matchmaking.connect_saved_partners(requester_id, responder_id)
+    if not connected:
+        await query.edit_message_text("⚠️ Reconnect failed because one user is busy now.")
+        bot = get_bot_from_callback(query, context)
+        if bot:
+            await bot.send_message(requester_id, "⚠️ Reconnect failed because one user is busy now.")
+        return
+
+    await query.edit_message_text(Messages.RECONNECT_ACCEPTED)
+    bot = get_bot_from_callback(query, context)
+    if bot:
+        await bot.send_message(requester_id, Messages.RECONNECT_ACCEPTED, reply_markup=Keyboards.chat_controls())
+        await bot.send_message(responder_id, Messages.RECONNECT_ACCEPTED, reply_markup=Keyboards.chat_controls())
+
 async def handle_skip_chat_callback(query, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle skip chat button callback"""
     user_id = query.from_user.id
@@ -1590,7 +1967,8 @@ async def handle_admin_callback(query, context: ContextTypes.DEFAULT_TYPE) -> No
                 reports_text += f"👤 Reporter: {reporter.nickname if reporter else 'Unknown'} (ID: {report.reporter_id})\n"
                 reports_text += f"🎯 Reported: {reported.nickname if reported else 'Unknown'} (ID: {report.reported_id})\n"
                 reports_text += f"📝 Reason: {report.reason or 'No reason provided'}\n"
-                reports_text += f"📅 Date: {report.created_at.strftime('%Y-%m-%d %H:%M')}\n\n"
+                report_date = report.created_at.strftime('%Y-%m-%d %H:%M') if report.created_at else 'Unknown'
+                reports_text += f"📅 Date: {report_date}\n\n"
             
             if len(reports) > 10:
                 reports_text += f"... and {len(reports) - 10} more reports"
@@ -1625,7 +2003,8 @@ async def handle_admin_callback(query, context: ContextTypes.DEFAULT_TYPE) -> No
             for user in banned_users[:15]:  # Show max 15
                 banned_text += f"**{user.nickname}** (ID: {user.user_id})\n"
                 banned_text += f"📝 Reason: {user.ban_reason or 'No reason'}\n"
-                banned_text += f"📅 Banned: {user.ban_date.strftime('%Y-%m-%d')}\n\n"
+                ban_date = user.ban_date.strftime('%Y-%m-%d') if user.ban_date else 'Unknown'
+                banned_text += f"📅 Banned: {ban_date}\n\n"
             
             if len(banned_users) > 15:
                 banned_text += f"... and {len(banned_users) - 15} more"
@@ -1671,17 +2050,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         await handle_profile_editing(update, context, editing_state)
         return
     
-    # Check if user is searching - block commands during search
-    if user_id in matchmaking.waiting_users:
-        await update.message.reply_text(
-            "🔍 You're currently searching for a partner. Please use the search control buttons or stop your search to use commands."
-        )
-        return
-    
     # Check if user is in chat
     partner_id = matchmaking.get_partner(user_id)
-    
+
     if partner_id:
+        if user_id in matchmaking.waiting_users:
+            matchmaking.waiting_users.discard(user_id)
         # Forward message to partner with content warning if needed
         if contains_inappropriate_content(message_text):
             await update.message.reply_text(Messages.WARNING_MESSAGE, parse_mode='Markdown')
@@ -1701,6 +2075,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
             logger.error(f"Failed to forward message: {e}")
             await update.message.reply_text("❌ Failed to send message. Your partner may have left.")
     else:
+        if user_id in matchmaking.waiting_users:
+            await update.message.reply_text(
+                "🔍 You're currently searching for a partner. Please use the search control buttons or stop your search to use commands."
+            )
+            return
+
         # User not in chat - show main menu
         with database.get_db() as db:
             user = database.get_user(db, user_id)
@@ -1970,6 +2350,63 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
                 reply_markup=Keyboards.main_menu()
             )
 
+async def handle_video(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle video messages"""
+    if not update.message or not update.message.video:
+        return
+
+    user_id = update.effective_user.id
+    partner_id = matchmaking.get_partner(user_id)
+
+    if partner_id:
+        try:
+            await context.bot.send_video(
+                partner_id,
+                update.message.video.file_id,
+                caption="🎬 Your chat partner sent you a video!",
+                protect_content=True
+            )
+        except TelegramError as e:
+            logger.error(f"Failed to forward video: {e}")
+            await update.message.reply_text("❌ Failed to send video. Your partner may have left.")
+    else:
+        await update.message.reply_text(
+            "🎬 To send videos, you need to be in an active chat.",
+            reply_markup=Keyboards.main_menu()
+        )
+
+
+async def handle_video_document(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle MP4 files sent as documents"""
+    if not update.message or not update.message.document:
+        return
+
+    mime_type = (update.message.document.mime_type or '').lower()
+    file_name = (update.message.document.file_name or '').lower()
+    if mime_type != 'video/mp4' and not file_name.endswith('.mp4'):
+        return
+
+    user_id = update.effective_user.id
+    partner_id = matchmaking.get_partner(user_id)
+
+    if partner_id:
+        try:
+            await context.bot.send_document(
+                partner_id,
+                update.message.document.file_id,
+                caption="🎬 Your chat partner sent you an MP4 video file!",
+                protect_content=True
+            )
+        except TelegramError as e:
+            logger.error(f"Failed to forward MP4 document: {e}")
+            await update.message.reply_text("❌ Failed to send MP4. Your partner may have left.")
+    else:
+        await update.message.reply_text(
+            "🎬 To send MP4 files, you need to be in an active chat.",
+            reply_markup=Keyboards.main_menu()
+        )
+
+
 async def handle_sticker(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle sticker messages"""
     if not update.message or not update.message.sticker:
@@ -2110,6 +2547,7 @@ def main() -> None:
     application.add_handler(CommandHandler("skip", skip_command))
     application.add_handler(CommandHandler("stop", stop_command))
     application.add_handler(CommandHandler("report", report_command))
+    application.add_handler(CommandHandler("saved", saved_command))
     application.add_handler(CommandHandler("profile", profile_command))
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("privacy", privacy_command))
@@ -2118,6 +2556,8 @@ def main() -> None:
     
     application.add_handler(CallbackQueryHandler(button_callback))
     application.add_handler(MessageHandler(filters.PHOTO, handle_photo))
+    application.add_handler(MessageHandler(filters.VIDEO, handle_video))
+    application.add_handler(MessageHandler(filters.Document.MimeType("video/mp4"), handle_video_document))
     application.add_handler(MessageHandler(filters.Sticker.ALL, handle_sticker))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, block_personal_info),group=0)
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
@@ -2129,6 +2569,7 @@ def main() -> None:
             BotCommand("find", "Find a chat partner"),
             BotCommand("skip", "Skip current chat partner"),
             BotCommand("stop", "End current chat"),
+            BotCommand("saved", "View saved chats"),
             BotCommand("profile", "View/edit your profile"),
             BotCommand("viewonce", "Send a view-once disappearing photo"),
             BotCommand("help", "Show help menu"),
@@ -2157,6 +2598,11 @@ def main() -> None:
     application.add_error_handler(error_handler)
     
     # Start polling (drop pending updates to avoid conflicts with other instances)
+    if not acquire_polling_lock():
+        logger.info("Replica is idle because another instance owns polling lock")
+        while True:
+            time.sleep(60)
+
     logger.info("Bot started successfully")
     application.run_polling(allowed_updates=Update.ALL_TYPES, drop_pending_updates=True)
 

--- a/database.py
+++ b/database.py
@@ -121,6 +121,18 @@ class BroadcastMessage(Base):
     created_at = Column(DateTime, default=datetime.utcnow)
     completed_at = Column(DateTime, nullable=True)
 
+
+class SavedChat(Base):
+    __tablename__ = 'saved_chats'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    owner_id = Column(BigInteger, ForeignKey('users.user_id'), nullable=False)
+    partner_id = Column(BigInteger, ForeignKey('users.user_id'), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    owner = relationship("User", foreign_keys=[owner_id])
+    partner = relationship("User", foreign_keys=[partner_id])
+
 @contextmanager
 def get_db():
     """Database session context manager"""
@@ -167,6 +179,114 @@ def init_database():
                     pass  # Column might already exist or other issue
             
             logger.info("Database migration completed successfully")
+
+            # Create or migrate saved chats table
+            try:
+                conn.execute(text(
+                    """
+                    CREATE TABLE IF NOT EXISTS saved_chats (
+                        id SERIAL PRIMARY KEY,
+                        owner_id BIGINT,
+                        partner_id BIGINT,
+                        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    )
+                    """
+                ))
+                conn.commit()
+
+                saved_chat_columns = {
+                    row[0]
+                    for row in conn.execute(text(
+                        "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'saved_chats'"
+                    ))
+                }
+
+                if 'owner_id' not in saved_chat_columns:
+                    conn.execute(text("ALTER TABLE saved_chats ADD COLUMN owner_id BIGINT"))
+                    conn.commit()
+                    if 'user_id' in saved_chat_columns:
+                        conn.execute(text("UPDATE saved_chats SET owner_id = user_id WHERE owner_id IS NULL"))
+                        conn.commit()
+
+                if 'partner_id' not in saved_chat_columns:
+                    conn.execute(text("ALTER TABLE saved_chats ADD COLUMN partner_id BIGINT"))
+                    conn.commit()
+                    if 'partner_user_id' in saved_chat_columns:
+                        conn.execute(text("UPDATE saved_chats SET partner_id = partner_user_id WHERE partner_id IS NULL"))
+                        conn.commit()
+
+                if 'user_id' in saved_chat_columns and 'owner_id' in saved_chat_columns:
+                    conn.execute(text("UPDATE saved_chats SET user_id = owner_id WHERE user_id IS NULL AND owner_id IS NOT NULL"))
+                    conn.commit()
+
+                if 'partner_user_id' in saved_chat_columns and 'partner_id' in saved_chat_columns:
+                    conn.execute(text("UPDATE saved_chats SET partner_user_id = partner_id WHERE partner_user_id IS NULL AND partner_id IS NOT NULL"))
+                    conn.commit()
+
+                conn.execute(text("ALTER TABLE saved_chats ADD COLUMN IF NOT EXISTS created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP"))
+                conn.execute(text("DELETE FROM saved_chats WHERE owner_id IS NULL OR partner_id IS NULL"))
+                conn.commit()
+
+                try:
+                    conn.execute(text("ALTER TABLE saved_chats ALTER COLUMN owner_id SET NOT NULL"))
+                    conn.execute(text("ALTER TABLE saved_chats ALTER COLUMN partner_id SET NOT NULL"))
+                    conn.commit()
+                except Exception as not_null_error:
+                    logger.warning(f"Saved chats NOT NULL migration warning: {not_null_error}")
+                    conn.rollback()
+
+                conn.execute(text("CREATE INDEX IF NOT EXISTS idx_saved_chats_owner_id ON saved_chats(owner_id)"))
+                conn.execute(text("CREATE UNIQUE INDEX IF NOT EXISTS uq_saved_chats_owner_partner ON saved_chats(owner_id, partner_id)"))
+                conn.commit()
+
+                try:
+                    conn.execute(text(
+                        """
+                        DO $$
+                        BEGIN
+                            IF NOT EXISTS (
+                                SELECT 1
+                                FROM pg_constraint
+                                WHERE conname = 'fk_saved_chats_owner_id'
+                            ) THEN
+                                ALTER TABLE saved_chats
+                                ADD CONSTRAINT fk_saved_chats_owner_id
+                                FOREIGN KEY (owner_id) REFERENCES users(user_id) ON DELETE CASCADE;
+                            END IF;
+                        END
+                        $$;
+                        """
+                    ))
+                    conn.commit()
+                except Exception as owner_fk_error:
+                    logger.warning(f"Saved chats owner FK migration warning: {owner_fk_error}")
+                    conn.rollback()
+
+                try:
+                    conn.execute(text(
+                        """
+                        DO $$
+                        BEGIN
+                            IF NOT EXISTS (
+                                SELECT 1
+                                FROM pg_constraint
+                                WHERE conname = 'fk_saved_chats_partner_id'
+                            ) THEN
+                                ALTER TABLE saved_chats
+                                ADD CONSTRAINT fk_saved_chats_partner_id
+                                FOREIGN KEY (partner_id) REFERENCES users(user_id) ON DELETE CASCADE;
+                            END IF;
+                        END
+                        $$;
+                        """
+                    ))
+                    conn.commit()
+                except Exception as partner_fk_error:
+                    logger.warning(f"Saved chats partner FK migration warning: {partner_fk_error}")
+                    conn.rollback()
+            except Exception as migration_error:
+                logger.error(f"Saved chats migration failed: {migration_error}")
+                conn.rollback()
     except Exception as e:
         logger.error(f"Failed to create database tables: {e}")
         raise
@@ -408,3 +528,140 @@ def update_broadcast_stats(db, broadcast_id: int, sent_count: int, failed_count:
         broadcast.failed_count = failed_count
         broadcast.completed_at = datetime.utcnow()
         db.flush()
+
+
+def _get_saved_chat_columns(db):
+    """Detect saved_chats owner/partner column names for legacy compatibility"""
+    rows = db.execute(text(
+        "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'saved_chats'"
+    )).fetchall()
+    columns = {row[0] for row in rows}
+
+    owner_col = 'owner_id' if 'owner_id' in columns else 'user_id' if 'user_id' in columns else None
+    partner_col = 'partner_id' if 'partner_id' in columns else 'partner_user_id' if 'partner_user_id' in columns else None
+    return owner_col, partner_col
+
+
+def _get_saved_chat_column_set(db) -> Set[str]:
+    """Get all columns currently present in saved_chats table"""
+    rows = db.execute(text(
+        "SELECT column_name FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'saved_chats'"
+    )).fetchall()
+    return {row[0] for row in rows}
+
+
+def get_saved_chat(db, owner_id: int, partner_id: int) -> Optional[SavedChat]:
+    """Get one saved chat for owner and partner"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return None
+
+    query = text(
+        f"SELECT id, {owner_col} AS owner_id, {partner_col} AS partner_id, created_at FROM saved_chats "
+        f"WHERE {owner_col} = :owner_id AND {partner_col} = :partner_id LIMIT 1"
+    )
+    row = db.execute(query, {'owner_id': owner_id, 'partner_id': partner_id}).fetchone()
+    if not row:
+        return None
+
+    record = SavedChat()
+    record.id = row[0]
+    record.owner_id = row[1]
+    record.partner_id = row[2]
+    record.created_at = row[3]
+    return record
+
+
+def get_saved_chats_for_owner(db, owner_id: int) -> List[SavedChat]:
+    """Get all saved chats for one owner"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return []
+
+    query = text(
+        f"SELECT id, {owner_col} AS owner_id, {partner_col} AS partner_id, created_at FROM saved_chats "
+        f"WHERE {owner_col} = :owner_id ORDER BY created_at DESC"
+    )
+    rows = db.execute(query, {'owner_id': owner_id}).fetchall()
+
+    results = []
+    for row in rows:
+        record = SavedChat()
+        record.id = row[0]
+        record.owner_id = row[1]
+        record.partner_id = row[2]
+        record.created_at = row[3]
+        results.append(record)
+    return results
+
+
+def count_saved_chats_for_owner(db, owner_id: int) -> int:
+    """Count saved chats for one owner"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return 0
+
+    query = text(f"SELECT COUNT(*) FROM saved_chats WHERE {owner_col} = :owner_id")
+    return db.execute(query, {'owner_id': owner_id}).scalar() or 0
+
+
+def create_saved_chat(db, owner_id: int, partner_id: int) -> Optional[SavedChat]:
+    """Create a saved chat if it does not exist"""
+    existing = get_saved_chat(db, owner_id, partner_id)
+    if existing:
+        return existing
+
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return None
+
+    columns = _get_saved_chat_column_set(db)
+    insert_fields = [owner_col, partner_col]
+    params = {
+        'owner_id': owner_id,
+        'partner_id': partner_id,
+    }
+
+    if 'user_id' in columns and 'user_id' not in insert_fields:
+        insert_fields.append('user_id')
+        params['user_id'] = owner_id
+
+    if 'partner_user_id' in columns and 'partner_user_id' not in insert_fields:
+        insert_fields.append('partner_user_id')
+        params['partner_user_id'] = partner_id
+
+    values_clause = []
+    for field in insert_fields:
+        if field == owner_col:
+            values_clause.append(':owner_id')
+        elif field == partner_col:
+            values_clause.append(':partner_id')
+        else:
+            values_clause.append(f':{field}')
+
+    insert_query = text(
+        f"INSERT INTO saved_chats ({', '.join(insert_fields)}) VALUES ({', '.join(values_clause)}) RETURNING id, created_at"
+    )
+    row = db.execute(insert_query, params).fetchone()
+    if not row:
+        return None
+
+    record = SavedChat()
+    record.id = row[0]
+    record.owner_id = owner_id
+    record.partner_id = partner_id
+    record.created_at = row[1]
+    return record
+
+
+def delete_saved_chat(db, owner_id: int, partner_id: int) -> bool:
+    """Delete one saved chat"""
+    owner_col, partner_col = _get_saved_chat_columns(db)
+    if not owner_col or not partner_col:
+        return False
+
+    delete_query = text(
+        f"DELETE FROM saved_chats WHERE {owner_col} = :owner_id AND {partner_col} = :partner_id"
+    )
+    result = db.execute(delete_query, {'owner_id': owner_id, 'partner_id': partner_id})
+    return result.rowcount > 0


### PR DESCRIPTION
### Motivation
- Logs showed `Conflict: terminated by other getUpdates request` from multi-replica Railway deployments which disrupts bot polling.  
- The bot crashed with `'NoneType' object has no attribute 'strftime'` while rendering profiles/reports/saved lists, causing callbacks (save/view) to become unresponsive.  
- Saved-chat UI and callback flows relied on Markdown and fragile timestamps which made the saved list unreliable.  
- Message forwarding could silently fail when session mappings became one-sided, so partner text/attachments were not always delivered.

### Description
- Added a PostgreSQL advisory lock gate via `acquire_polling_lock()` (uses `database.engine`, `RAILWAY_PROJECT_ID`/`RAILWAY_SERVICE_ID` and `hashlib`) so only one replica runs `getUpdates`, and non-owner replicas stay idle instead of competing.  
- Hardened date handling by guarding nullable datetime fields (e.g. `created_at`, `ban_date`, report dates) before calling `strftime` to prevent `NoneType` errors.  
- Reworked saved-chat support: created `SavedChat` model + migration logic, and added robust helpers in `database.py` (`get_saved_chat`, `get_saved_chats_for_owner`, `create_saved_chat`, `delete_saved_chat`, `count_saved_chats_for_owner`) that tolerate legacy column names; built a plain-text saved-menu in `build_saved_chat_menu()` and stopped using `parse_mode='Markdown'` for dynamic saved/profile views.  
- Restored and hardened saved-chat flows and callbacks: new keyboard rows and handlers (`save_chat`, `save_accept_*`, `save_decline_*`, `saved_reconnect_*`, reconnect handlers), a `pending_save_requests` set stored in `bot_data`, and `get_bot_from_callback()` helper to reliably send response messages.  
- Improved matchmaking/session reliability by repairing one-sided mappings in `MatchmakingService.get_partner()` and adding `connect_saved_partners()` to create active sessions for saved reconnects.  
- Added safe forwarding support for media (`handle_video`, `handle_video_document`) and adjusted `handle_message` to clear waiting state and better handle forwarding errors.  
- Minor fixes and reliability changes: added `hashlib` import, updated menus/keyboards to include saved features, and ensured startup gating uses the polling lock before calling `application.run_polling()`.

### Testing
- Compiled the modified modules with `python -m py_compile anonymous_chat_bot.py database.py` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922462e9908322a5c55512741e3306)